### PR TITLE
Testing setup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,10 @@
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+import DOVE.src._utils as dutils
+
+if importlib.util.find_spec("ravenframework") is None:
+  sys.path.append(dutils.get_raven_loc())

--- a/coverage_scripts/.coveragerc
+++ b/coverage_scripts/.coveragerc
@@ -1,0 +1,32 @@
+# .coveragerc to control coverage.py
+[run]
+#branch = True
+parallel = True
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    #def __repr__
+    #if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    raise IOError
+    raise Exception
+
+    # Don't complain for the things under development
+    pragma: under development
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+[html]
+directory = tests/coverage_html_report

--- a/coverage_scripts/check_py_coverage.sh
+++ b/coverage_scripts/check_py_coverage.sh
@@ -1,41 +1,49 @@
 #!/bin/bash
-SCRIPT_DIRNAME=`dirname $0`
-DOVE_DIR=`(cd $SCRIPT_DIRNAME/..; pwd)`
-cd $DOVE_DIR
-RAVEN_DIR=`python -c 'from src._utils import get_raven_loc; print(get_raven_loc())'`
+SCRIPT_DIRNAME=`dirname $(readlink -f "$0")`
+DOVE_LOC=`(cd $SCRIPT_DIRNAME/..; pwd)`
+cd $DOVE_LOC
 
-source $DOVE_DIR/coverage_scripts/initialize_coverage.sh
+# Add parent dir of DOVE to path to allow imports from DOVE
+DOVE_DIR=`(cd $DOVE_LOC/..; pwd)`
+OLD_PYTHONPATH=$PYTHONPATH
+    if [[ "$OLD_PYTHONPATH" == "" ]]; then
+      export PYTHONPATH="$DOVE_DIR"
+    else
+       export PYTHONPATH="$OLD_PYTHONPATH:$DOVE_DIR"
+    fi
+
+RAVEN_DIR=`python -c 'from src._utils import get_raven_loc; print(get_raven_loc())'`
+# If raven directory has been added to PYTHONPATH, this confuses get_raven_loc
+if [[ "$RAVEN_DIR" == *"ravenframework" ]]  # get_raven_loc might return ravenframework, not raven
+then
+    RAVEN_DIR=`(cd $RAVEN_DIR/..; pwd)`  # Take parent directory, which is raven directory, instead
+fi
+
+source $DOVE_LOC/coverage_scripts/initialize_coverage.sh
 
 #coverage help run
-SRC_DIR=`(cd src && pwd)`
+SRC_DIR=`(cd src; pwd)`
 # For some reason, when the --source and --omit flags for coverage run in line 19 contain files with bash-style ("/c/*")
 # file paths, coverage.py does not interpret them correctly. It would seem to treat them as relative file paths.
 # This only occurs in DOVE, only when running through rook. These lines edit the src path to instead start with "C:".
 # TODO figure out why this happens and fix it there if possible
-echo $SRC_DIR
 if [[ "$SRC_DIR" == "/c"* ]]
 then
-    echo $SRC_DIR
     SRC_DIR="C:${SRC_DIR:2}"
-else
-    echo "It still didn't work"
 fi
 
 export COVERAGE_RCFILE="$SRC_DIR/../coverage_scripts/.coveragerc"
-echo $SRC_DIR
 SOURCE_DIRS=($SRC_DIR)
-echo $SOURCE_DIRS
 OMIT_FILES=($SRC_DIR/Dispatch/twin_pyomo_test.py,$SRC_DIR/Dispatch/twin_pyomo_test_rte.py,$SRC_DIR/Dispatch/twin_pyomo_limited_ramp.py,$SRC_DIR/Dispatch/twin_pyomo_test_ch_disch.py)
 EXTRA="--source=${SOURCE_DIRS[@]} --omit=${OMIT_FILES[@]} --parallel-mode"
 export COVERAGE_FILE=`pwd`/.coverage
-
 coverage erase
 ($RAVEN_DIR/run_tests "$@" --re=DOVE/tests --python-command="coverage run $EXTRA" ||
                                             echo run_tests done but some tests failed)
 
-## Prepare data and generate the html documents
+# Prepare data and generate the html documents
 coverage combine
 coverage html
 
 # See report_py_coverage.sh file for explanation of script separation
-(bash $DOVE_DIR/coverage_scripts/report_py_coverage.sh --data-file=$COVERAGE_FILE --coverage-rc-file=$COVERAGE_RCFILE)
+(bash $DOVE_LOC/coverage_scripts/report_py_coverage.sh --data-file=$COVERAGE_FILE --coverage-rc-file=$COVERAGE_RCFILE)

--- a/coverage_scripts/check_py_coverage.sh
+++ b/coverage_scripts/check_py_coverage.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+SCRIPT_DIRNAME=`dirname $0`
+DOVE_DIR=`(cd $SCRIPT_DIRNAME/..; pwd)`
+cd $DOVE_DIR
+RAVEN_DIR=`python -c 'from src._utils import get_raven_loc; print(get_raven_loc())'`
+
+source $DOVE_DIR/coverage_scripts/initialize_coverage.sh
+
+#coverage help run
+SRC_DIR=`(cd src && pwd)`
+# For some reason, when the --source and --omit flags for coverage run in line 19 contain files with bash-style ("/c/*")
+# file paths, coverage.py does not interpret them correctly. It would seem to treat them as relative file paths.
+# This only occurs in DOVE, only when running through rook. These lines edit the src path to instead start with "C:".
+# TODO figure out why this happens and fix it there if possible
+echo $SRC_DIR
+if [[ "$SRC_DIR" == "/c"* ]]
+then
+    echo $SRC_DIR
+    SRC_DIR="C:${SRC_DIR:2}"
+else
+    echo "It still didn't work"
+fi
+
+export COVERAGE_RCFILE="$SRC_DIR/../coverage_scripts/.coveragerc"
+echo $SRC_DIR
+SOURCE_DIRS=($SRC_DIR)
+echo $SOURCE_DIRS
+OMIT_FILES=($SRC_DIR/Dispatch/twin_pyomo_test.py,$SRC_DIR/Dispatch/twin_pyomo_test_rte.py,$SRC_DIR/Dispatch/twin_pyomo_limited_ramp.py,$SRC_DIR/Dispatch/twin_pyomo_test_ch_disch.py)
+EXTRA="--source=${SOURCE_DIRS[@]} --omit=${OMIT_FILES[@]} --parallel-mode"
+export COVERAGE_FILE=`pwd`/.coverage
+
+coverage erase
+($RAVEN_DIR/run_tests "$@" --re=DOVE/tests --python-command="coverage run $EXTRA" ||
+                                            echo run_tests done but some tests failed)
+
+## Prepare data and generate the html documents
+coverage combine
+coverage html
+
+# See report_py_coverage.sh file for explanation of script separation
+(bash $DOVE_DIR/coverage_scripts/report_py_coverage.sh --data-file=$COVERAGE_FILE --coverage-rc-file=$COVERAGE_RCFILE)

--- a/coverage_scripts/initialize_coverage.sh
+++ b/coverage_scripts/initialize_coverage.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# This script prepares for running commands from the coverage package
+
+SCRIPT_DIRNAME=`dirname $0`
+DOVE_DIR=`(cd $SCRIPT_DIRNAME/..; pwd)`
+echo $DOVE_DIR
+cd $DOVE_DIR
+RAVEN_DIR=`python -c 'from src._utils import get_raven_loc; print(get_raven_loc())'`
+source $RAVEN_DIR/scripts/establish_conda_env.sh --quiet --load
+RAVEN_LIBS_PATH=`conda env list | awk -v rln="$RAVEN_LIBS_NAME" '$0 ~ rln {print $NF}'`
+BUILD_DIR=${BUILD_DIR:=$RAVEN_LIBS_PATH/build}
+INSTALL_DIR=${INSTALL_DIR:=$RAVEN_LIBS_PATH}
+PYTHON_CMD=${PYTHON_CMD:=python}
+mkdir -p $BUILD_DIR
+mkdir -p $INSTALL_DIR
+DOWNLOADER='curl -C - -L -O '
+
+ORIGPYTHONPATH="$PYTHONPATH"
+
+update_python_path ()
+{
+    if ls -d $INSTALL_DIR/lib/python*
+    then
+        export PYTHONPATH=`ls -d $INSTALL_DIR/lib/python*/site-packages/`:"$ORIGPYTHONPATH"
+    fi
+}
+
+update_python_path
+export PATH=$INSTALL_DIR/bin:$PATH
+
+if which coverage
+then
+    echo coverage already available, skipping building it.
+else
+    if curl http://www.energy.gov > /dev/null
+    then
+       echo Successfully got data from the internet
+    else
+       echo Could not connect to internet
+    fi
+
+    cd $BUILD_DIR
+    #SHA256=56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1
+    $DOWNLOADER https://files.pythonhosted.org/packages/ef/05/31553dc038667012853d0a248b57987d8d70b2d67ea885605f87bcb1baba/coverage-7.5.4.tar.gz
+    tar -xvzf coverage-7.5.4.tar.gz
+    cd coverage-7.5.4
+    (unset CC CXX; $PYTHON_CMD setup.py install --prefix=$INSTALL_DIR)
+fi
+
+update_python_path

--- a/coverage_scripts/report_py_coverage.sh
+++ b/coverage_scripts/report_py_coverage.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# To be run after a run of check_py_coverage.sh
+# This script has been separated from check_py_coverage.sh for the github action, so that
+#   the output of run_tests within check_py_coverage.sh can be printed, but the report
+#   value can be caught and put in an annotation. This is necessary because calling
+#   "coverage report --format=total" directly in the yaml does not work
+
+SCRIPT_DIRNAME=`dirname $0`
+DOVE_DIR=`(cd $SCRIPT_DIRNAME/..; pwd)`
+cd $DOVE_DIR
+
+source coverage_scripts/initialize_coverage.sh > /dev/null 2>&1
+
+# read command-line arguments
+ARGS=()
+for A in "$@"
+do
+  case $A in
+    --data-file=*)
+      export COVERAGE_FILE="${A#--data-file=}"  # Removes "--data-file=" and puts path into env variable
+      ;;
+    --coverage-rc-file=*)
+      export COVERAGE_RCFILE="${A#--coverage-rc-file=}"  # See above
+      ;;
+    *)
+      ARGS+=("$A")
+      ;;
+  esac
+done
+
+COV_VAL=`coverage report --format=total "${ARGS[@]}"`
+if [[ $COV_VAL = "No data to report." ]]
+then
+  echo "Could not find data file with coverage results."
+  exit 0
+fi
+
+echo "Coverage for this repository is now $COV_VAL%."

--- a/coverage_scripts/report_py_coverage.sh
+++ b/coverage_scripts/report_py_coverage.sh
@@ -7,8 +7,8 @@
 #   "coverage report --format=total" directly in the yaml does not work
 
 SCRIPT_DIRNAME=`dirname $0`
-DOVE_DIR=`(cd $SCRIPT_DIRNAME/..; pwd)`
-cd $DOVE_DIR
+DOVE_LOC=`(cd $SCRIPT_DIRNAME/..; pwd)`
+cd $DOVE_LOC
 
 source coverage_scripts/initialize_coverage.sh > /dev/null 2>&1
 

--- a/src/Dispatch/__init__.py
+++ b/src/Dispatch/__init__.py
@@ -1,2 +1,13 @@
 # Copyright 2020, Battelle Energy Alliance, LLC
 # ALL RIGHTS RESERVED
+
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+import DOVE.src._utils as dutils
+
+if importlib.util.find_spec("ravenframework") is None:
+  sys.path.append(dutils.get_raven_loc())

--- a/src/Economics/__init__.py
+++ b/src/Economics/__init__.py
@@ -1,3 +1,14 @@
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+import DOVE.src._utils as dutils
+
+if importlib.util.find_spec("ravenframework") is None:
+  sys.path.append(dutils.get_raven_loc())
+
 from .CashFlow import CashFlow
 from .CashFlowGroup import CashFlowGroup
 

--- a/src/Interactions/__init__.py
+++ b/src/Interactions/__init__.py
@@ -1,3 +1,14 @@
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+import DOVE.src._utils as dutils
+
+if importlib.util.find_spec("ravenframework") is None:
+  sys.path.append(dutils.get_raven_loc())
+
 # only type references here, as needed
 from .Demand import Demand
 from .Interaction import Interaction

--- a/src/TransferFuncs/__init__.py
+++ b/src/TransferFuncs/__init__.py
@@ -4,6 +4,17 @@ resources for generating components. This module defines the templates
 that can be used to describe transfer functions.
 """
 
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+import DOVE.src._utils as dutils
+
+if importlib.util.find_spec("ravenframework") is None:
+  sys.path.append(dutils.get_raven_loc())
+
 # only type references here, as needed
 # provide easy name access to module
 from .Factory import factory

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,11 +1,13 @@
 import importlib
+import os
 import sys
 
-from ._utils import get_raven_loc
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+import DOVE.src._utils as dutils
 
 if importlib.util.find_spec("ravenframework") is None:
-  ravenframework_loc = get_raven_loc()
-  sys.path.append(ravenframework_loc)
+  sys.path.append(dutils.get_raven_loc())
 
 from .Base import Base
 from .Components import Component

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+import DOVE.src._utils as dutils
+
+if importlib.util.find_spec("ravenframework") is None:
+  sys.path.append(dutils.get_raven_loc())

--- a/tests/unit_tests/__init__.py
+++ b/tests/unit_tests/__init__.py
@@ -1,0 +1,10 @@
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
+import DOVE.src._utils as dutils
+
+if importlib.util.find_spec("ravenframework") is None:
+  sys.path.append(dutils.get_raven_loc())

--- a/tests/unit_tests/test_components.py
+++ b/tests/unit_tests/test_components.py
@@ -1,3 +1,5 @@
+import __init__  # Running __init__ here enables importing from DOVE and RAVEN
+
 import unittest
 from unittest.mock import MagicMock, call, patch, ANY
 

--- a/tests/unit_tests/tests
+++ b/tests/unit_tests/tests
@@ -1,0 +1,6 @@
+[Tests]
+  [./test_components]
+    type = 'Unittest'
+    input = 'test_components.TestComponent'
+  [../]
+[]


### PR DESCRIPTION
These changes enable the running of DOVE tests through rook and the RAVEN `run_tests` file.
-  A `tests` file was added for the current unit test, so it can be found by rook.
- Scripts for checking coverage similar to those in HERON have been added.
- To prevent issues with pathing, the `__init__.py` files have been updated. These files must be imported at the top of every unit (and potentially integration) test, which has been implemented in the current unit test. The issue was that scripts were unable to import from `DOVE` or `raven` because the parent directories of `DOVE` and `raven` were not in the `sys.path`. The `__init__.py` files in a directory are run whenever that directory is imported as a package or one of the files it contains is imported as a module. Thus, adding the parent directories of `DOVE` and `raven` to `sys.path` in the `__init__.py` files solves the error for the majority of the files in `DOVE` since these files are run only after being imported. For exceptions, such as unit tests, importing (and thus automatically running) the `__init__.py` file in the same directory as the file will solve the issue.