### PR TITLE
Unit tests for PriceTakerBuilder

### DIFF
--- a/tests/unit/models/price_taker/test_builder.py
+++ b/tests/unit/models/price_taker/test_builder.py
@@ -1,0 +1,93 @@
+# Copyright 2024, Battelle Energy Alliance, LLC
+# ALL RIGHTS RESERVED
+""" """
+
+import numpy as np
+import pyomo.environ as pyo
+import pytest
+
+import dove.core as dc
+from dove.models import BUILDER_REGISTRY
+
+
+@pytest.fixture()
+def create_example_system():
+    """
+    This establishes a simple system on which we can test the builder.
+    It features multiple resources, multiple storage and non-storage components, and multiple timesteps.
+    """
+
+    ### Set up resources
+
+    elec = dc.Resource("electricity")
+    steam = dc.Resource("steam")
+
+    resources = [elec, steam]
+
+    ### Set up components
+
+    # Non-storage
+    steam_source = dc.Source(name="steam_source", produces=steam, max_capacity=1.0)
+
+    steam_to_elec_converter = dc.Converter(
+        name="steam_to_elec_converter",
+        max_capacity=1.0,
+        consumes=[steam],
+        produces=[elec],
+        capacity_resource=steam,
+    )
+
+    elec_sink = dc.Sink(name="elec_sink", consumes=elec, max_capacity=1.0)
+
+    # Storage
+    steam_storage = dc.Storage(name="steam_storage", resource=steam, max_capacity=1.0)
+    elec_storage = dc.Storage(name="elec_storage", resource=elec, max_capacity=1.0)
+
+    components = [steam_source, steam_to_elec_converter, elec_sink, steam_storage, elec_storage]
+
+    ### Set up times
+    time_index = np.array([0, 1])
+
+    ### Create and return system
+    sys = dc.System(components, resources, time_index)
+    return sys
+
+
+@pytest.fixture()
+def builder_setup(create_example_system):
+    price_taker_builder_cls = BUILDER_REGISTRY["price_taker"]
+    price_taker_builder = price_taker_builder_cls(create_example_system)
+    price_taker_builder.model = pyo.ConcreteModel()
+    price_taker_builder.model.system = price_taker_builder.system
+
+    return price_taker_builder
+
+
+def test_add_sets(builder_setup):
+    # Call method under test
+    builder_setup._add_sets()
+
+    # Find the actual pyo.Set variables and extract data as tuples of strings
+
+    m = builder_setup.model
+
+    actual_non_storage = m.NON_STORAGE.data()
+    actual_storage = m.STORAGE.data()
+    actual_r = m.R.data()
+    actual_t = m.T.data()
+
+    # Find the expected values for the sets as lists of strings
+
+    sys = builder_setup.system
+
+    expected_non_storage = sys.non_storage_comp_names
+    expected_storage = sys.storage_comp_names
+    expected_r = [r.name for r in sys.resources]
+    expected_t = sys.time_index
+
+    # Convert both actual (tuple) and expected (list) values to sets and check that they're the same
+
+    assert set(actual_non_storage) == set(expected_non_storage)
+    assert set(actual_storage) == set(expected_storage)
+    assert set(actual_r) == set(expected_r)
+    assert set(actual_t) == set(expected_t)

--- a/tests/unit/models/price_taker/test_builder.py
+++ b/tests/unit/models/price_taker/test_builder.py
@@ -2,6 +2,8 @@
 # ALL RIGHTS RESERVED
 """ """
 
+from itertools import product
+
 import numpy as np
 import pyomo.environ as pyo
 import pytest
@@ -19,15 +21,19 @@ def create_example_system():
 
     ### Set up resources
 
-    elec = dc.Resource("electricity")
     steam = dc.Resource("steam")
+    elec = dc.Resource("electricity")
 
-    resources = [elec, steam]
+    resources = [steam, elec]
 
     ### Set up components
 
     # Non-storage
-    steam_source = dc.Source(name="steam_source", produces=steam, max_capacity=1.0)
+    steam_source = dc.Source(
+        name="steam_source",
+        produces=steam,
+        max_capacity=2.0,
+    )
 
     steam_to_elec_converter = dc.Converter(
         name="steam_to_elec_converter",
@@ -35,18 +41,37 @@ def create_example_system():
         consumes=[steam],
         produces=[elec],
         capacity_resource=steam,
+        transfer_fn=dc.RatioTransfer(input_res=steam, output_res=elec, ratio=0.5),
     )
 
-    elec_sink = dc.Sink(name="elec_sink", consumes=elec, max_capacity=1.0)
+    elec_sink = dc.Sink(
+        name="elec_sink",
+        consumes=elec,
+        max_capacity=1.0,
+        min_capacity=0.5,
+        profile=np.array([1.0, 0.0, 1.0]),
+    )
 
     # Storage
-    steam_storage = dc.Storage(name="steam_storage", resource=steam, max_capacity=1.0)
-    elec_storage = dc.Storage(name="elec_storage", resource=elec, max_capacity=1.0)
+    steam_storage = dc.Storage(
+        name="steam_storage",
+        resource=steam,
+        max_capacity=1.0,
+        profile=np.array([0.0, 0.5, 0.0]),
+    )
+
+    elec_storage = dc.Storage(
+        name="elec_storage",
+        resource=elec,
+        max_charge_rate=0.5,
+        max_discharge_rate=0.25,
+        max_capacity=2.0,
+    )
 
     components = [steam_source, steam_to_elec_converter, elec_sink, steam_storage, elec_storage]
 
     ### Set up times
-    time_index = np.array([0, 1])
+    time_index = np.array([0, 1, 2])
 
     ### Create and return system
     sys = dc.System(components, resources, time_index)
@@ -67,7 +92,7 @@ def test_add_sets(builder_setup):
     # Call method under test
     builder_setup._add_sets()
 
-    # Find the actual pyo.Set variables and extract data as tuples of strings
+    # Find the actual pyo.Set objects and extract data as tuples of strings
 
     m = builder_setup.model
 
@@ -85,9 +110,422 @@ def test_add_sets(builder_setup):
     expected_r = [r.name for r in sys.resources]
     expected_t = sys.time_index
 
-    # Convert both actual (tuple) and expected (list) values to sets and check that they're the same
+    # Convert both actual (tuple) and expected (list) values to the same types and check their values
 
     assert set(actual_non_storage) == set(expected_non_storage)
     assert set(actual_storage) == set(expected_storage)
     assert set(actual_r) == set(expected_r)
-    assert set(actual_t) == set(expected_t)
+    assert (list(actual_t) == expected_t).all()  # We do care about the order for this one
+
+
+def test_add_variables(builder_setup):
+    # Add sets to builder so the variables can use them
+    builder_setup._add_sets()
+
+    # Call method under test
+    builder_setup._add_variables()
+
+    # Find the actual pyo.Var objects and extract data into dicts, then get the set of keys
+    # We care about the keys because these are the bins for the var to later populate with values
+
+    m = builder_setup.model
+
+    actual_flow_keys = set(m.flow.get_values().keys())
+    actual_soc_keys = set(m.SOC.get_values().keys())
+    actual_charge_keys = set(m.charge.get_values().keys())
+    actual_discharge_keys = set(m.discharge.get_values().keys())
+
+    # Build combinations for keys in expected content of vars
+
+    sys = builder_setup.system
+    res_names = [r.name for r in sys.resources]
+
+    expected_flow_keys = set(product(sys.non_storage_comp_names, res_names, sys.time_index))
+    expected_storage_keys = set(product(sys.storage_comp_names, sys.time_index))
+
+    # Check that sets of keys are as expected
+    assert actual_flow_keys == expected_flow_keys
+    assert actual_soc_keys == expected_storage_keys
+    assert actual_charge_keys == expected_storage_keys
+    assert actual_discharge_keys == expected_storage_keys
+
+
+@pytest.fixture()
+def add_constraints_setup(builder_setup):
+    # Add sets and variables to builder so the constraints can use them
+    builder_setup._add_sets()
+    builder_setup._add_variables()
+
+    # Call method under test
+    builder_setup._add_constraints()
+    return builder_setup
+
+
+@pytest.fixture()
+def check_constraint():
+    def _check_constraint(
+        model: pyo.ConcreteModel, constr_name: str, is_equality_constr: bool, expected_result: dict
+    ) -> None:
+        """
+        Ensure constraint is correct by checking that it exists, that the keys are correct,
+        that it is is of the type (equality/inequality) expected, and that it is satisfied when expected.
+
+        Parameters
+        ----------
+        model: pyo.ConcreteModel
+            The Pyomo model on which the constraints are being tested.
+        constr_name: str
+            The expected name of the constraint on the model.
+        is_equality_constr: bool
+            Whether this constraint is expected to be an equality constraint (created with ==).
+        expected_result: dict
+            A dict with keys that are tuples that mirror the expected keys of the constraint (or bins for the
+            constraint to populate) and values that are bools with the expected feasibility of the constraint.
+        """
+        actual_constr = getattr(model, constr_name, None)
+
+        assert actual_constr is not None
+        assert set(actual_constr.keys()) == set(expected_result.keys())
+
+        for (
+            case,  # Cases are tuples (e.g., ("steam_source", 0))
+            value,  # Values are bools (for whether the constraint should be feasible)
+        ) in expected_result.items():
+            specific_constr = actual_constr[case]
+
+            assert specific_constr.equality == is_equality_constr
+            assert specific_constr.has_lb() or specific_constr.has_ub()
+
+            satisfies_lb = (
+                (specific_constr.body() >= specific_constr.lb) if specific_constr.has_lb() else True
+            )
+            satisfies_ub = (
+                (specific_constr.body() <= specific_constr.ub) if specific_constr.has_ub() else True
+            )
+            assert (satisfies_lb and satisfies_ub) == value
+
+    return _check_constraint
+
+
+def test_add_constraints_adds_transfer_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+    ### Transfer constraint
+
+    # Set up required vars for input
+    # Recall that for the converter, ratio_transfer ratio == 0.5
+    m.flow.set_values(
+        {
+            ("steam_to_elec_converter", "steam",       0): 0.0,
+            ("steam_to_elec_converter", "electricity", 0): 1.0,  # Out > 0.5 * In -> constr fails
+
+            ("steam_to_elec_converter", "steam",       1): 2.0,
+            ("steam_to_elec_converter", "electricity", 1): 1.0,  # Out == 0.5 * In -> constr satisfied
+
+            ("steam_to_elec_converter", "steam",       2): 1.0,
+            ("steam_to_elec_converter", "electricity", 2): 0.0,  # Out < 0.5 * In -> constr fails
+        }
+    )  # fmt: skip
+
+    # Expected results
+    expected_transfer_result = {
+        ("steam_to_elec_converter", 0): False,
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "transfer", True, expected_transfer_result)
+
+
+def test_add_constraints_adds_capacity_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    # Recall that:
+    # steam_source.max_capacity == 2.0
+    # steam_to_elec_converter.max_capacity == 1.0
+    # elec_sink.max_capacity == 1.0
+    m.flow.set_values(
+        {
+            ("steam_source", "steam", 0): 1.0,  # < max_capacity -> constr satisfied
+            ("steam_source", "steam", 1): 2.0,  # = max_capacity -> constr satisfied
+            ("steam_source", "steam", 2): 3.0,  # > max_capacity -> constr fails
+            ("steam_to_elec_converter", "steam", 0): 0.0,  # < max_capacity -> constr satisfied
+            ("steam_to_elec_converter", "steam", 1): 1.0,  # = max_capacity -> constr satisfied
+            ("steam_to_elec_converter", "steam", 2): 2.0,  # > max_capacity -> constr fails
+            ("elec_sink", "electricity", 0): 0.0,  # < max_capacity -> constr satisfied
+            ("elec_sink", "electricity", 1): 1.0,  # = max_capacity -> constr satisfied
+            ("elec_sink", "electricity", 2): 2.0,  # > max_capacity -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_cap_result = {
+        ("steam_source", 0): True,
+        ("steam_source", 1): True,
+        ("steam_source", 2): False,
+        ("steam_to_elec_converter", 0): True,
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): False,
+        ("elec_sink", 0): True,
+        ("elec_sink", 1): True,
+        ("elec_sink", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "capacity", False, expected_cap_result)
+
+
+def test_add_constraints_adds_min_capacity_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    # Recall that elec_sink.min_capacity == 0.5; default is 0.0
+    m.flow.set_values(
+        {
+            ("steam_source", "steam", 0): 0.0,  # = min_capacity -> constr satisfied
+            ("steam_source", "steam", 1): 0.0,  # = min_capacity -> constr satisfied
+            ("steam_source", "steam", 2): 0.0,  # = min_capacity -> constr satisfied
+            ("steam_to_elec_converter", "steam", 0): 0.0,  # = min_capacity -> constr satisfied
+            ("steam_to_elec_converter", "steam", 1): 0.0,  # = min_capacity -> constr satisfied
+            ("steam_to_elec_converter", "steam", 2): 0.0,  # = min_capacity -> constr satisfied
+            ("elec_sink", "electricity", 0): 0.0,  # < min_capacity -> constr fails
+            ("elec_sink", "electricity", 1): 0.5,  # = min_capacity -> constr satisfied
+            ("elec_sink", "electricity", 2): 1.0,  # > min_capacity -> constr satisfied
+        }
+    )
+
+    # Expected results
+    expected_min_cap_result = {
+        ("steam_source", 0): True,
+        ("steam_source", 1): True,
+        ("steam_source", 2): True,
+        ("steam_to_elec_converter", 0): True,
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): True,
+        ("elec_sink", 0): False,
+        ("elec_sink", 1): True,
+        ("elec_sink", 2): True,
+    }
+
+    # Verify constraint
+    check_constraint(m, "min_capacity", False, expected_min_cap_result)
+
+
+@pytest.mark.skip("TODO if necessary")
+def test_add_constraints_adds_fixed_profile_constraint(add_constraints_setup, check_constraint):
+    # TODO if this constraint is not removed soon
+    pass
+
+
+def test_add_constraints_adds_resource_balance_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    m.flow.set_values(
+        {
+            ("steam_source",            "steam",       0): 1.0,
+            ("steam_to_elec_converter", "steam",       0): 1.0,
+            ("steam_to_elec_converter", "electricity", 0): 1.0,
+            ("elec_sink",               "electricity", 0): 1.0,
+            ("steam_source",            "steam",       1): 2.0,
+            ("steam_to_elec_converter", "steam",       1): 2.0,
+            ("steam_to_elec_converter", "electricity", 1): 1.0,
+            ("elec_sink",               "electricity", 1): 1.0,
+            ("steam_source",            "steam",       2): 1.0,
+            ("steam_to_elec_converter", "steam",       2): 1.0,
+            ("steam_to_elec_converter", "electricity", 2): 1.0,
+            ("elec_sink",               "electricity", 2): 1.0,
+        }
+    )  # fmt: skip
+
+    m.charge.set_values(
+        {
+            ("steam_storage", 0): 0.0,
+            ("steam_storage", 1): 1.0,
+            ("steam_storage", 2): 2.0,
+            ("elec_storage", 0): 0.0,
+            ("elec_storage", 1): 1.0,
+            ("elec_storage", 2): 2.0,
+        }
+    )
+
+    m.discharge.set_values(
+        {
+            ("steam_storage", 0): 1.0,
+            ("steam_storage", 1): 1.0,
+            ("steam_storage", 2): 1.0,
+            ("elec_storage", 0): 1.0,
+            ("elec_storage", 1): 1.0,
+            ("elec_storage", 2): 1.0,
+        }
+    )
+
+    # Expected results
+    expected_res_balance_result = {
+        ("steam", 0): False,
+        ("steam", 1): True,
+        ("steam", 2): False,
+        ("electricity", 0): False,
+        ("electricity", 1): True,
+        ("electricity", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "resource_balance", True, expected_res_balance_result)
+
+
+def test_add_constraints_adds_storage_balance_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    # Recall that default rte == 1.0; default initial_stored == 0.0
+    m.charge.set_values(
+        {
+            ("steam_storage", 0): 1.0,
+            ("steam_storage", 1): 2.0,
+            ("steam_storage", 2): 0.0,
+            ("elec_storage", 0): 1.0,
+            ("elec_storage", 1): 2.0,
+            ("elec_storage", 2): 0.0,
+        }
+    )
+
+    m.discharge.set_values(
+        {
+            ("steam_storage", 0): 0.0,
+            ("steam_storage", 1): 1.0,
+            ("steam_storage", 2): 0.0,
+            ("elec_storage", 0): 0.0,
+            ("elec_storage", 1): 1.0,
+            ("elec_storage", 2): 0.0,
+        }
+    )
+
+    m.SOC.set_values(
+        {
+            ("steam_storage", 0): 0.0,
+            ("steam_storage", 1): 1.0,
+            ("steam_storage", 2): 2.0,
+            ("elec_storage", 0): 0.0,
+            ("elec_storage", 1): 1.0,
+            ("elec_storage", 2): 2.0,
+        }
+    )
+
+    # Expected results
+    expected_storage_balance_result = {
+        ("steam_storage", 0): False,
+        ("steam_storage", 1): True,
+        ("steam_storage", 2): False,
+        ("elec_storage", 0): False,
+        ("elec_storage", 1): True,
+        ("elec_storage", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "storage_balance", True, expected_storage_balance_result)
+
+
+def test_add_constraints_adds_charge_limit_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    # Recall that for steam storage, max_capacity = 1, default max_charge_rate = 1
+    # For elec storage, max_charge_rate = 0.5, max_capacity = 2
+    m.charge.set_values(
+        {
+            ("steam_storage", 0): 0.0,  # < max_charge_rate * max_capacity -> constr satisfied
+            ("steam_storage", 1): 1.0,  # = max_charge_rate * max_capacity -> constr satisfied
+            ("steam_storage", 2): 2.0,  # > max_charge_rate * max_capacity -> constr fails
+            ("elec_storage", 0): 0.0,  # < max_charge_rate * max_capacity -> constr satisfied
+            ("elec_storage", 1): 1.0,  # = max_charge_rate * max_capacity -> constr satisfied
+            ("elec_storage", 2): 2.0,  # > max_charge_rate * max_capacity -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_charge_limit_result = {
+        ("steam_storage", 0): True,
+        ("steam_storage", 1): True,
+        ("steam_storage", 2): False,
+        ("elec_storage", 0): True,
+        ("elec_storage", 1): True,
+        ("elec_storage", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "charge_limit", False, expected_charge_limit_result)
+
+
+def test_add_constraints_adds_discharge_limit_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    # Recall that for steam storage, max_capacity = 1, default max_discharge_rate = 1
+    # For elec storage, max_capacity = 2, max_discharge_rate = 0.25
+    m.discharge.set_values(
+        {
+            ("steam_storage", 0): 0.0,  # < max_discharge_rate * max_capacity -> constr satisfied
+            ("steam_storage", 1): 1.0,  # = max_discharge_rate * max_capacity -> constr satisfied
+            ("steam_storage", 2): 2.0,  # > max_discharge_rate * max_capacity -> constr fails
+            ("elec_storage", 0): 0.0,  # < max_discharge_rate * max_capacity -> constr satisfied
+            ("elec_storage", 1): 0.5,  # = max_discharge_rate * max_capacity -> constr satisfied
+            ("elec_storage", 2): 1.0,  # > max_discharge_rate * max_capacity -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_discharge_limit_result = {
+        ("steam_storage", 0): True,
+        ("steam_storage", 1): True,
+        ("steam_storage", 2): False,
+        ("elec_storage", 0): True,
+        ("elec_storage", 1): True,
+        ("elec_storage", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "discharge_limit", False, expected_discharge_limit_result)
+
+
+def test_add_constraints_adds_soc_limit_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    # Recall that steam storage max_capacity = 1; elec storage max_capacity = 2
+    m.SOC.set_values(
+        {
+            ("steam_storage", 0): 0.0,  # < max_capacity -> constr satisfied
+            ("steam_storage", 1): 1.0,  # = max_capacity -> constr satisfied
+            ("steam_storage", 2): 2.0,  # > max_capacity -> constr fails
+            ("elec_storage", 0): 1.0,  # < max_capacity -> constr satisfied
+            ("elec_storage", 1): 2.0,  # = max_capacity -> constr satisfied
+            ("elec_storage", 2): 3.0,  # > max_capacity -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_soc_limit_result = {
+        ("steam_storage", 0): True,
+        ("steam_storage", 1): True,
+        ("steam_storage", 2): False,
+        ("elec_storage", 0): True,
+        ("elec_storage", 1): True,
+        ("elec_storage", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "soc_limit", False, expected_soc_limit_result)
+
+
+def test_add_objective(add_constraints_setup):
+    # Call the method under test
+    add_constraints_setup._add_objective()
+
+    obj = add_constraints_setup.model.objective
+
+    # Just check that the maximizing objective was added and that it has a rule (hard to do much more here)
+    assert isinstance(obj, pyo.Objective)
+    assert obj.rule is not None
+    assert not obj.is_minimizing()


### PR DESCRIPTION
This adds unit tests for the `PriceTakerBuilder` class. It tests each method of the class except the `solve` method, which will be tested by regression tests and would be difficult to test with unit tests. It also does not test code related to the `fixed_profile` constraint, which may be removed soon.

While these tests do generate coverage for the rules in `src.dove.models.price_taker.rulelib.py`, they are not intended to test the rules rigorously.