### PR TITLE
Feature/expanded input verification and updated unit tests

### DIFF
--- a/src/dove/core/system.py
+++ b/src/dove/core/system.py
@@ -68,12 +68,14 @@ class System:
             The time periods for simulation. If None, [0] is used.
         """
         self.components: list[Component] = [] if components is None else components
+        self.verify_components_definition()
         self.resources: list[Resource] = [] if resources is None else resources
+        self.verify_resources_definition()
         self.time_index = [0] if time_index is None else time_index
         self.comp_map: dict[str, Component] = {comp.name: comp for comp in self.components}
         self.res_map: dict[str, Resource] = {res.name: res for res in self.resources}
         self._normalize_time_series(components=self.components)
-        self.verify()
+        self.verify_time_series()
 
     @property
     def non_storage_comp_names(self) -> list[str]:
@@ -104,34 +106,70 @@ class System:
         }
         print(info)
 
-    def verify(self) -> None:
+    def verify_components_definition(self) -> None:
         """
-        Verify the integrity of the system.
+        Verify that components are valid.
 
         Checks for:
+        - Type of components
         - Uniqueness of component names
-        - Uniqueness of resource names
-        - Consistency of time series lengths with the system time index
 
         Raises
         ------
+        TypeError
+            If any component is not of type Component
         ValueError
-            If any validation check fails:
-            - Component names are not unique
-            - Resource names are not unique
-            - Component profile length doesn't match time index length
-            - Cashflow price profile length doesn't match time index length
+            If component names are not unique
         """
+        # Check the types of the components
+        for comp in self.components:
+            if not isinstance(comp, Component):
+                raise TypeError(f"Type of {comp} is not Component.")
+
         # Check for unique component names
         component_names = [comp.name for comp in self.components]
         if len(component_names) != len(set(component_names)):
             raise ValueError("Component names must be unique!")
+
+    def verify_resources_definition(self) -> None:
+        """
+        Verify that resources are valid.
+
+        Checks for:
+        - Type of resources
+        - Uniqueness of resource names
+
+        Raises
+        ------
+        TypeError
+            If any resource is not of type Resource
+        ValueError
+            If resource names are not unique
+        """
+        # Check the types of the resources
+        for res in self.resources:
+            if not isinstance(res, Resource):
+                raise TypeError(f"Type of {res} is not Resource.")
 
         # Check for unique resource names
         resource_names = [res.name for res in self.resources]
         if len(resource_names) != len(set(resource_names)):
             raise ValueError("Resource names must be unique!")
 
+    def verify_time_series(self) -> None:
+        """
+        Verify the integrity of the system's time series.
+
+        Checks for:
+        - Consistency of time series lengths with the system time index
+
+        Raises
+        ------
+        ValueError
+            If either validation check fails:
+            - Component profile length doesn't match time index length
+            - Cashflow price profile length doesn't match time index length
+        """
         # Check that time index length matches profiles and price profiles
         for comp in self.components:
             if len(comp.profile) > 0 and len(comp.profile) != len(self.time_index):
@@ -164,8 +202,9 @@ class System:
             If the component validation fails (via verify method).
         """
         self.components.append(comp)
+        self.verify_components_definition()
         self._normalize_time_series(components=[comp])
-        self.verify()
+        self.verify_time_series()
         self.comp_map[comp.name] = comp
         return self
 
@@ -184,8 +223,8 @@ class System:
             The system instance for method chaining.
         """
         self.resources.append(res)
+        self.verify_resources_definition()
         self.res_map[res.name] = res
-        self.verify()
         return self
 
     def build(self) -> None:

--- a/src/dove/core/system.py
+++ b/src/dove/core/system.py
@@ -72,7 +72,8 @@ class System:
         self.time_index = [0] if time_index is None else time_index
         self.comp_map: dict[str, Component] = {comp.name: comp for comp in self.components}
         self.res_map: dict[str, Resource] = {res.name: res for res in self.resources}
-        self._normalize_time_series()
+        self._normalize_time_series(components=self.components)
+        self.verify()
 
     @property
     def non_storage_comp_names(self) -> list[str]:
@@ -133,12 +134,12 @@ class System:
 
         # Check that time index length matches profiles and price profiles
         for comp in self.components:
-            if comp.profile and len(comp.profile) != len(self.time_index):
+            if len(comp.profile) > 0 and len(comp.profile) != len(self.time_index):
                 raise ValueError(
                     f"Component '{comp.name}' has a profile length that does not match the time index length!"
                 )
             for cf in comp.cashflows:
-                if cf.price_profile and len(cf.price_profile) != len(self.time_index):
+                if len(cf.price_profile) > 0 and len(cf.price_profile) != len(self.time_index):
                     raise ValueError(
                         f"Component '{comp.name}' has a cashflow price profile length that does not match the time index length!"
                     )
@@ -163,6 +164,7 @@ class System:
             If the component validation fails (via verify method).
         """
         self.components.append(comp)
+        self._normalize_time_series(components=[comp])
         self.verify()
         self.comp_map[comp.name] = comp
         return self
@@ -183,6 +185,7 @@ class System:
         """
         self.resources.append(res)
         self.res_map[res.name] = res
+        self.verify()
         return self
 
     def build(self) -> None:
@@ -233,29 +236,37 @@ class System:
         builder.solve(**kw)
         return builder.extract_results()
 
-    def _normalize_time_series(self) -> None:
+    def _normalize_time_series(self, components: list[Component]) -> None:
         """
         Normalize time series data within components.
 
         This internal method:
         1. Scales capacity factor profiles by max_capacity
-        2. Handles fixed flexibility components by setting min_capacity
-           equal to max_capacity and creating a constant profile
+        2. Handles fixed flexibility components when the profile hasn't been explicitly defined by
+           setting min_capacity equal to max_capacity and creating a constant profile
         3. Expands cashflow price profiles to match the time index length
+        4. Scales cashflow price profiles by alpha
+
+        Parameters
+        ----------
+        components : list[Component]
+            The components whose time series data to normalize.
         """
         # I guess these are all the variables we might expect to be varying over time?
-        for comp in self.components:
+        for comp in components:
             if comp.capacity_factor:
                 # Means user has supplied a time-series profile to the component
                 # that represents the capacity factor
                 assert isinstance(comp.profile, np.ndarray)
                 comp.profile = comp.profile * comp.max_capacity
 
-            if comp.flexibility == "fixed":
+            if comp.flexibility == "fixed" and len(comp.profile) < 1:
                 # TODO: Move these into component constructor
                 comp.min_capacity = comp.max_capacity
                 comp.profile = np.full(len(self.time_index), comp.max_capacity)
 
             for cf in comp.cashflows:
                 if len(cf.price_profile) < 1:
-                    cf.price_profile = np.full(len(self.time_index), cf.alpha)
+                    cf.price_profile = np.full(len(self.time_index), 1)
+
+                cf.price_profile = np.multiply(cf.alpha, cf.price_profile)

--- a/tests/unit/test_system.py
+++ b/tests/unit/test_system.py
@@ -157,6 +157,26 @@ def test_system_setup(initialize_and_populate_system):
     assert len(storage.cashflows[0].price_profile) == 3
 
 
+def test_adding_non_component_to_components_raises_error(initialize_and_populate_system):
+    res = dc.Resource(name="res")
+    c1 = dc.Source(name="c1", produces=res, max_capacity=1.0)
+    with pytest.raises(TypeError):
+        initialize_and_populate_system(
+            resources=[res],
+            components=[c1, "c2"],  # c2 is a string, not a Component
+        )
+
+
+def test_adding_non_resource_to_resources_raises_error(initialize_and_populate_system):
+    r1 = dc.Resource(name="r1")
+    c = dc.Source(name="c1", produces=r1, max_capacity=1.0)
+    with pytest.raises(TypeError):
+        initialize_and_populate_system(
+            resources=[r1, "r2"],
+            components=[c],  # r2 is a string, not a Resource
+        )
+
+
 def test_adding_duplicate_component_name_raises_error(initialize_and_populate_system):
     r = dc.Resource(name="res")
     c1 = dc.Source(name="c", produces=r, max_capacity=1.0, min_capacity=0.0, profile=[0.1])

--- a/tests/unit/test_system.py
+++ b/tests/unit/test_system.py
@@ -2,103 +2,261 @@
 # ALL RIGHTS RESERVED
 """ """
 
+import numpy as np
 import pytest
 
-from dove.core import Resource, Source
-from dove.core.system import System
+import dove.core as dc
+
+### FIXTURE DEFINITIONS
+
+
+@pytest.fixture(
+    params=[
+        "populate_at_initialization",
+        "populate_after_initialization",
+        "populate_some_at_intialization",
+    ]
+)
+def initialize_and_populate_system(request):
+    def _initialize_and_populate_system(components, resources, **kw):
+        if request.param == "populate_at_initialization":
+            sys = dc.System(components=components, resources=resources, **kw)
+        elif request.param == "populate_after_initialization":
+            sys = dc.System(**kw)
+            for res in resources:
+                sys.add_resource(res)
+            for comp in components:
+                sys.add_component(comp)
+        else:
+            # Populate some at initialization
+            sys = dc.System(components=components[:1], resources=resources[:1], **kw)
+
+            # Populate the rest after
+            for res in resources[1:]:
+                sys.add_resource(res)
+            for comp in components[1:]:
+                sys.add_component(comp)
+
+        return sys
+
+    return _initialize_and_populate_system
+
+
+### TEST DEFINITIONS
 
 
 def test_system_initialization_empty():
-    sys = System()
+    sys = dc.System()
     assert isinstance(sys.components, list)
     assert sys.components == []
     assert isinstance(sys.resources, list)
     assert sys.resources == []
 
 
-# def test_add_and_get_components_and_resources():
-#   sys = System()
-#   r_w = Resource(name="water")
-#   r_e = Resource(name="electricity")
-#   src = Source(name="src", max_capacity=10.0, produces=r_w)
-#   sink = Sink(name="sink", max_capacity=5.0, consumes=r_w)
-#   conv = Converter(name="conv", max_capacity=8.0, consumes=[r_w], produces=[r_e])
-#   sys.add_component(src)
-#   sys.add_component(sink)
-#   sys.add_component(conv)
+def test_system_summary(capsys):
+    r = dc.Resource(name="res")
+    src = dc.Source(name="src", max_capacity=4.0, produces=r)
+    sink = dc.Sink(name="sink", max_capacity=2.0, consumes=r)
+    storage = dc.Storage(name="storage", max_capacity=1.0, resource=r)
+    sys = dc.System(components=[src, sink, storage], resources=[r])
 
-#   # components list updated
-#   assert src in sys.components
-#   assert sink in sys.components
-#   assert conv in sys.components
+    sys.summary()  # Pytest will automatically capture stdout
+    captured = capsys.readouterr()
 
-#   # resources registered
-#   assert "water" in sys.resources
-#   assert "electricity" in sys.resources
-#   assert sys.resources["water"] is r_w
-#   assert sys.resources["electricity"] is r_e
+    # Just some quick checks to make sure we're at least printing something relatively helpful
+    assert "res" in captured.out
+    assert "src" in captured.out
+    assert "sink" in captured.out
+    assert "storage" in captured.out
 
 
-def test_adding_duplicate_component_name_raises():
-    sys = System()
-    r = Resource(name="res")
-    c1 = Source(name="c", produces=r, max_capacity=1.0, min_capacity=0.0, profile=[0.1])
-    c2 = Source(name="c", produces=r, max_capacity=2.0, min_capacity=0.0, profile=[0.2])
-    sys.add_component(c1)
+def test_system_setup(initialize_and_populate_system):
+    """
+    Tests __init__, add_component, add_resource, non_storage_comp_names, and storage_comp_names
+    """
+    r_w = dc.Resource(name="water")
+    r_e = dc.Resource(name="electricity")
+
+    src = dc.Source(
+        name="src",
+        max_capacity=10.0,
+        produces=r_w,
+        cashflows=[dc.Cost(name="src_cf", alpha=2)],
+    )
+    sink = dc.Sink(
+        name="sink",
+        max_capacity=5.0,
+        consumes=r_e,
+        cashflows=[dc.Cost(name="sink_cf", alpha=2)],
+    )
+    conv = dc.Converter(
+        name="conv",
+        max_capacity=8.0,
+        consumes=[r_w],
+        produces=[r_e],
+        capacity_resource=r_w,
+        transfer_fn=dc.RatioTransfer(input_res=r_w, output_res=r_e, ratio=1.0),
+        cashflows=[dc.Cost(name="conv_cf", alpha=2)],
+    )
+    storage = dc.Storage(
+        name="storage",
+        max_capacity=2.0,
+        resource=r_e,
+        cashflows=[dc.Cost(name="storage_cf", alpha=2)],
+    )
+
+    # Automatically test with each setup methodology:
+    # - Adding components and resources at initialization
+    # - Adding components and resources after initialization
+    # - Adding some components and resources at initialization and some after
+    sys = initialize_and_populate_system(
+        components=[src, sink, conv, storage], resources=[r_w, r_e], time_index=np.array([1, 2, 4])
+    )
+
+    # Check component list
+    assert src in sys.components
+    assert sink in sys.components
+    assert conv in sys.components
+    assert storage in sys.components
+
+    # Check component map
+    assert sys.comp_map["src"] is src
+    assert sys.comp_map["sink"] is sink
+    assert sys.comp_map["conv"] is conv
+    assert sys.comp_map["storage"] is storage
+
+    # Check storage and non-storage component name lists
+    assert "src" in sys.non_storage_comp_names
+    assert "sink" in sys.non_storage_comp_names
+    assert "conv" in sys.non_storage_comp_names
+    assert "storage" in sys.storage_comp_names
+
+    # Check resource list
+    assert r_w in sys.resources
+    assert r_e in sys.resources
+
+    # Check resource map
+    assert sys.res_map["water"] is r_w
+    assert sys.res_map["electricity"] is r_e
+
+    # Check time index
+    assert (sys.time_index == np.array([1, 2, 4])).all()
+
+    # Check that time series were normalized
+    # NOT a thorough test of normalization; just checking that it was called for each component
+    assert src.cashflows[0].price_profile is not None
+    assert len(src.cashflows[0].price_profile) == 3
+
+    assert sink.cashflows[0].price_profile is not None
+    assert len(sink.cashflows[0].price_profile) == 3
+
+    assert conv.cashflows[0].price_profile is not None
+    assert len(conv.cashflows[0].price_profile) == 3
+
+    assert storage.cashflows[0].price_profile is not None
+    assert len(storage.cashflows[0].price_profile) == 3
+
+
+def test_adding_duplicate_component_name_raises_error(initialize_and_populate_system):
+    r = dc.Resource(name="res")
+    c1 = dc.Source(name="c", produces=r, max_capacity=1.0, min_capacity=0.0, profile=[0.1])
+    c2 = dc.Source(name="c", produces=r, max_capacity=2.0, min_capacity=0.0, profile=[0.2])
     with pytest.raises(ValueError):
-        sys.add_component(c2)
+        initialize_and_populate_system(resources=[r], components=[c1, c2])
 
 
-# def test_remove_component_and_resource_cleanup():
-#   sys = System()
-#   r = Resource(name="resA")
-#   src = Source(name="srcA", max_capacity=3.0, produces=r)
-#   sys.add_component(src)
-#   sys.remove_component("srcA")
-#   assert src not in sys.components
-#   # resource still in system? implementation choice: assume removal if unused
-#   assert "resA" not in sys.resources
+def test_adding_duplicate_resource_name_raises_error(initialize_and_populate_system):
+    r1 = dc.Resource(name="res")
+    r2 = dc.Resource(name="res")
+    c1 = dc.Source(name="c1", produces=r1, max_capacity=1.0, min_capacity=0.0, profile=[0.1])
+    c2 = dc.Source(name="c2", produces=r2, max_capacity=2.0, min_capacity=0.0, profile=[0.2])
+    with pytest.raises(ValueError):
+        initialize_and_populate_system(resources=[r1, r2], components=[c1, c2])
 
 
-# def test_system_summary_dict():
-#   sys = System()
-#   r = Resource(name="resB")
-#   src = Source(name="srcB", max_capacity=4.0, produces=r)
-#   sink = Sink(name="sinkB", max_capacity=2.0, consumes=r)
-#   sys.add_component(src)
-#   sys.add_component(sink)
-#   summary = sys.summary()
-#   assert isinstance(summary, dict)
-#   assert "components" in summary and isinstance(summary["components"], list)
-#   names = [c["name"] for c in summary["components"]]
-#   assert set(names) == {"srcB", "sinkB"}
-#   assert "resources" in summary and "resB" in summary["resources"]
+def test_inconsistent_comp_profile_length_raises_error(initialize_and_populate_system):
+    r = dc.Resource(name="res")
+    c = dc.Source(name="c", produces=r, max_capacity=1.0, min_capacity=0.0, profile=[0.1])
+    with pytest.raises(ValueError):
+        initialize_and_populate_system(resources=[r], components=[c], time_index=[1, 2])
 
 
-# def test_run_without_components_returns_empty():
-#   sys = System(name="empty_run")
-#   result = sys.run()
-#   # Expect result to be an empty array or dict, depending on impl
-#   assert result is not None
+def test_inconsistent_cf_price_profile_length_raises_error(initialize_and_populate_system):
+    r = dc.Resource(name="res")
+    c = dc.Source(
+        name="c",
+        produces=r,
+        max_capacity=1.0,
+        min_capacity=0.0,
+        profile=[0.1, 0.2],
+        cashflows=[dc.Cost(name="cf", price_profile=np.array([2]))],
+    )
+    with pytest.raises(ValueError):
+        initialize_and_populate_system(resources=[r], components=[c], time_index=[1, 2])
 
 
-# def test_run_simple_flow_produces_expected_profile():
-#   sys = System(name="flow_sys")
-#   r = Resource(name="resC")
-#   profile = [1.0, 0.5, 0.0]
-#   src = Source(name="srcC", max_capacity=5.0, produces=r, profile=profile)
-#   sink = Sink(name="sinkC", max_capacity=5.0, consumes=r)
-#   sys.add_component(src)
-#   sys.add_component(sink)
-#   timeline = sys.run()
-#   # Assuming run returns a time-series dict of resource balances
-#   assert hasattr(timeline, "shape") or isinstance(timeline, dict)
+def test_solve_with_unknown_model_type_raises_error():
+    r = dc.Resource(name="res")
+    src = dc.Source(name="src", produces=r, max_capacity=1.0)
+    sink = dc.Sink(name="sink", consumes=r, max_capacity=1.0)
+    sys = dc.System(components=[src, sink], resources=[r])
+
+    with pytest.raises(ValueError):
+        sys.solve(model_type="quantum_mechanical")  # We don't have a quantum_mechanical model
 
 
-# def test_optimizer_integration_placeholder():
-#   sys = System(name="opt_sys")
-#   # This is a placeholder for testing optimizer integration
-#   # e.g. sys.optimize(), check it returns optimal dispatch
-#   assert hasattr(sys, "optimize")
-#   with pytest.raises(NotImplementedError):
-#     sys.optimize()
+def test_normalize_time_series():
+    r1 = dc.Resource(name="r1")
+    r2 = dc.Resource(name="r2")
+
+    cap_factor_comp = dc.Source(
+        name="src",
+        produces=r1,
+        max_capacity=10,
+        profile=[0.5, 1.0, 0.5],
+        capacity_factor=True,
+        cashflows=[dc.Cost(name="src_cost", alpha=2)],  # No price profile
+    )
+    fixed_flex_comp = dc.Sink(
+        name="sink",
+        consumes=r2,
+        max_capacity=4,
+        flexibility="fixed",
+        cashflows=[
+            dc.Revenue(
+                name="sink_revenue",
+                alpha=2,
+                price_profile=np.array([2, 3, 4]),  # Price profile and alpha
+            )
+        ],
+    )
+    cap_factor_and_fixed_flex_comp = dc.Converter(
+        name="conv",
+        consumes=[r1],
+        produces=[r2],
+        max_capacity=5,
+        capacity_resource=r1,
+        profile=[0.8, 0.6, 0.6],
+        capacity_factor=True,
+        flexibility="fixed",
+        transfer_fn=dc.RatioTransfer(input_res=r1, output_res=r2, ratio=0.5),
+    )
+
+    # Constructing the system should automatically normalize components
+    sys = dc.System(
+        components=[cap_factor_comp, fixed_flex_comp],  # Only two of the components
+        resources=[r1, r2],
+        time_index=np.array([1, 2, 3]),
+    )
+
+    # Adding a component should automatically normalize it also
+    sys.add_component(cap_factor_and_fixed_flex_comp)
+
+    # Check component profiles
+    assert (sys.comp_map["src"].profile == np.array([5.0, 10.0, 5.0])).all()
+    assert (sys.comp_map["sink"].profile == np.array([4.0, 4.0, 4.0])).all()
+    assert (sys.comp_map["conv"].profile == np.array([4.0, 3.0, 3.0])).all()
+
+    # Check cashflow price profiles
+    assert (sys.comp_map["src"].cashflows[0].price_profile == np.array([2, 2, 2])).all()
+    assert (sys.comp_map["sink"].cashflows[0].price_profile == np.array([4, 6, 8])).all()


### PR DESCRIPTION
Addresses #14 and #16, among other changes.

**Input verification**
This seeks to minimize debugging time for users by erroring out quickly and with clarity when classes are not defined properly. It adds or modifies input verification for:
- `System`
    - Validity of added components is checked, despite the way they are added to the system
    - Validity of added resources is checked, despite the way they are added to the system
- `Component`
    - Checks that added resources are lists of resources
- `Source`
    - Ensures that "consumes" and "capacity_resource" kwargs have not been specified by the user
- `Sink`
    - Ensures that "produces" and "capacity_resource" kwargs have not been specified by the user
- `Converter`
    - Checks that a transfer function has been explicitly provided by the user. The justification for the decision to add this explicit requirement is as follows:
        - Currently, failing to add a transfer function explicitly to a converter causes an error (e.g.,  #16) because there is no default transfer function for converters, but the builder expects all non-storage components to have a transfer function. This change raises an error that has significantly improved clarity.
        - The transfer function is a fundamental concept for converters. Adding a default 1:1 ratio transfer would be somewhat arbitrary. Consider a converter that takes in steam and outputs electricity. Unit conversions alone would violate the 1:1 ratio assumption. Relative to adding a default transfer function, forcing the user to clarify the desired functionality of the converter is likely to encourage users to appropriately consider the desired scenario and to ease debugging for users.
- `Storage`
    - Ensures that `produces`, `consumes`, and `capacity_resource` kwargs have not been specified by the user

**Fixes**
- `System._normalize_time_series`
    - This method is now called whenever a component is added to the system (fixes #14)
    - Adds a `components` argument to the method definition, which enables normalization of only a subset of the system's components. This is necessary when components are added using the `System.add_component` method.
    - Multiplies the `price_profile` of relevant cashflows by the cashflow's `alpha`, which is the desired functionality of the economics calculations but was mistakenly not accounted for

**Unit tests**
In addition to adding unit tests for each of the changes listed above, this updates the set of unit tests for the System class.