### PR TITLE
feat: add periodic level constraint to model

### DIFF
--- a/src/dove/models/__init__.py
+++ b/src/dove/models/__init__.py
@@ -35,11 +35,12 @@ if TYPE_CHECKING:
 BUILDER_REGISTRY: dict[str, type["BaseModelBuilder"]] = {}
 
 
-def register_builder(name: str) -> Callable[[type["BaseModelBuilder"]], None]:
-    """ """
+def register_builder(name: str) -> Callable[[type["BaseModelBuilder"]], type["BaseModelBuilder"]]:
+    """Register a model builder class under the given name."""
 
-    def _decorator(cls: type["BaseModelBuilder"]) -> None:
+    def _decorator(cls: type["BaseModelBuilder"]) -> type["BaseModelBuilder"]:
         BUILDER_REGISTRY[name] = cls
+        return cls
 
     return _decorator
 

--- a/src/dove/models/price_taker/builder.py
+++ b/src/dove/models/price_taker/builder.py
@@ -228,6 +228,7 @@ class PriceTakerBuilder(BaseModelBuilder):
         m.charge_limit = pyo.Constraint(m.STORAGE, m.T, rule=prl.charge_limit_rule)
         m.discharge_limit = pyo.Constraint(m.STORAGE, m.T, rule=prl.discharge_limit_rule)
         m.soc_limit = pyo.Constraint(m.STORAGE, m.T, rule=prl.soc_limit_rule)
+        m.periodic_storage = pyo.Constraint(m.STORAGE, rule=prl.periodic_storage_rule)
 
         # Ramp Constraints
         m.ramp_up_limit = pyo.Constraint(m.NON_STORAGE, m.T, rule=prl.ramp_up_rule)

--- a/src/dove/models/price_taker/rulelib.py
+++ b/src/dove/models/price_taker/rulelib.py
@@ -588,6 +588,33 @@ def soc_limit_rule(m: pyo.ConcreteModel, sname: str, t: int) -> pyo.Expression:
     return m.soc[sname, t] <= comp.max_capacity
 
 
+def periodic_storage_rule(m: pyo.ConcreteModel, sname: str) -> pyo.Constraint:
+    """
+    Enforce periodic storage level for a storage component.
+
+    This constraint ensures that the state of charge (SOC) at the final time step
+    equals the initial state of charge, respecting the `initial_stored` attribute.
+
+    Parameters
+    ----------
+    m : pyo.ConcreteModel
+        The Pyomo model instance containing system components and variables.
+    sname : str
+        The name of the storage component.
+
+    Returns
+    -------
+    pyo.Constraint
+        A Pyomo constraint enforcing periodic storage level.
+    """
+    comp = m.system.comp_map[sname]
+    if not comp.periodic_level:
+        return pyo.Constraint.Skip
+
+    # Enforce SOC at the final time step equals the initial SOC
+    return m.soc[sname, m.T.last()] == comp.initial_stored * comp.max_capacity
+
+
 def objective_rule(m: pyo.ConcreteModel) -> pyo.Expression:
     """
     Calculate the objective function expression for a price-taker optimization model.


### PR DESCRIPTION
Adds a new constraint to `rulelib.py` called `periodic_storage_rule()` that forces the final storage level to be equal to the starting `initial_storage` level. 

Closes #23 