### PR TITLE
Add unit tests for ramping

### DIFF
--- a/src/dove/core/components.py
+++ b/src/dove/core/components.py
@@ -312,10 +312,11 @@ class Converter(Component):
         Perform post-initialization validation and setup.
 
         This method calls the parent class's post-initialization and then:
-        1. If no capacity_resource was provided, attempts to determine one:
+        1. Validates ramp_limit and ramp_freq values
+        2. If no capacity_resource was provided, attempts to determine one:
            - If the same resource is consumed and produced, uses that resource
            - Otherwise raises an error indicating ambiguity
-        2. Warns or raises errors if capacity_resource is ambiguous
+        3. Warns or raises errors if capacity_resource is ambiguous
 
         Raises
         ------
@@ -328,6 +329,10 @@ class Converter(Component):
         if not (0.0 <= self.ramp_limit <= 1.0):
             raise ValueError(
                 f"Converter {self.name}: 'ramp_limit'={self.ramp_limit} is outside the range [0, 1].",
+            )
+        if self.ramp_freq < 0:
+            raise ValueError(
+                f"Converter {self.name}: 'ramp_freq'={self.ramp_freq} must be positive"
             )
 
         # If no capacity_resource was provided, pick one or error out

--- a/src/dove/models/price_taker/rulelib.py
+++ b/src/dove/models/price_taker/rulelib.py
@@ -404,9 +404,9 @@ def steady_state_lower_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Con
     if not hasattr(comp, "ramp_freq") or comp.ramp_freq == 0 or t == m.T.first():
         return pyo.Constraint.Skip
 
-    # If steady_bin is 1, then flow difference must be >= 0
-    M = 2 * comp.max_capacity
-    return m.ramp_down[cname, t] >= -M * (1 - m.steady_bin[cname, t])
+    # If steady_bin is 1, then flow difference must be <= 0
+    M = 2 * comp.max_capacity_profile[t]
+    return m.ramp_down[cname, t] <= -M * (1 - m.steady_bin[cname, t])
 
 
 def state_selection_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:

--- a/tests/unit/models/price_taker/test_builder.py
+++ b/tests/unit/models/price_taker/test_builder.py
@@ -42,6 +42,8 @@ def create_example_system():
         consumes=[steam],
         produces=[elec],
         capacity_resource=steam,
+        ramp_freq=2,
+        ramp_limit=0.4,
         transfer_fn=dc.RatioTransfer(input_res=steam, output_res=elec, ratio=0.5),
     )
 
@@ -57,8 +59,9 @@ def create_example_system():
     steam_storage = dc.Storage(
         name="steam_storage",
         resource=steam,
-        max_capacity=1.0,
-        # profile=np.array([0.0, 0.5, 0.0]),
+        max_capacity_profile=[1.0, 1.0, 1.0],
+        initial_stored=0.5,
+        periodic_level=True,
     )
 
     elec_storage = dc.Storage(
@@ -66,7 +69,9 @@ def create_example_system():
         resource=elec,
         max_charge_rate=0.5,
         max_discharge_rate=0.25,
-        max_capacity=2.0,
+        max_capacity_profile=[2.0, 2.0, 2.0],
+        initial_stored=0.2,
+        periodic_level=False,
     )
 
     components = [steam_source, steam_to_elec_converter, elec_sink, steam_storage, elec_storage]
@@ -132,9 +137,16 @@ def test_add_variables(builder_setup):
     m = builder_setup.model
 
     actual_flow_keys = set(m.flow.get_values().keys())
+
     actual_soc_keys = set(m.soc.get_values().keys())
     actual_charge_keys = set(m.charge.get_values().keys())
     actual_discharge_keys = set(m.discharge.get_values().keys())
+
+    actual_ramp_up_keys = set(m.ramp_up.get_values().keys())
+    actual_ramp_down_keys = set(m.ramp_down.get_values().keys())
+    actual_ramp_up_bin_keys = set(m.ramp_up_bin.get_values().keys())
+    actual_ramp_down_bin_keys = set(m.ramp_down_bin.get_values().keys())
+    actual_steady_bin_keys = set(m.steady_bin.get_values().keys())
 
     # Build combinations for keys in expected content of vars
 
@@ -143,12 +155,20 @@ def test_add_variables(builder_setup):
 
     expected_flow_keys = set(product(sys.non_storage_comp_names, res_names, sys.time_index))
     expected_storage_keys = set(product(sys.storage_comp_names, sys.time_index))
+    expected_ramp_keys = set(product(sys.non_storage_comp_names, sys.time_index))
 
     # Check that sets of keys are as expected
     assert actual_flow_keys == expected_flow_keys
+
     assert actual_soc_keys == expected_storage_keys
     assert actual_charge_keys == expected_storage_keys
     assert actual_discharge_keys == expected_storage_keys
+
+    assert actual_ramp_up_keys == expected_ramp_keys
+    assert actual_ramp_down_keys == expected_ramp_keys
+    assert actual_ramp_up_bin_keys == expected_ramp_keys
+    assert actual_ramp_down_bin_keys == expected_ramp_keys
+    assert actual_steady_bin_keys == expected_ramp_keys
 
 
 @pytest.fixture()
@@ -518,6 +538,326 @@ def test_add_constraints_adds_soc_limit_constraint(add_constraints_setup, check_
 
     # Verify constraint
     check_constraint(m, "soc_limit", False, expected_soc_limit_result)
+
+
+def test_add_constraints_adds_periodic_storage_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    # Recall that steam storage initial_stored = 0.5; elec storage periodic_level = False
+    m.soc.set_values(
+        {
+            ("steam_storage", 0): 0.0,
+            ("steam_storage", 1): 1.0,
+            ("steam_storage", 2): 0.0,  # < initial_stored -> constr fails
+            ("elec_storage", 0): 1.0,
+            ("elec_storage", 1): 2.0,
+            ("elec_storage", 2): 2.0,  # no level requirement -> constr skipped
+        }
+    )
+
+    # Expected results
+    expected_periodic_level_result = {"steam_storage": False}
+
+    # Verify constraint
+    check_constraint(m, "periodic_storage", True, expected_periodic_level_result)
+
+
+def test_add_constraints_adds_ramp_up_limit_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    # Recall that steam to elec converter ramp_limit = 0.5; max_capacity_profile = [1, 1, 1]
+    m.flow.set_values(
+        {
+            ("steam_to_elec_converter", "steam", 0): 0.0,  # first t -> constraint skipped
+            ("steam_to_elec_converter", "steam", 1): 0.4,  # == max allowed ramp -> constr satisfied
+            ("steam_to_elec_converter", "steam", 2): 1.0,  # > max allowed ramp -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_ramp_up_limit_results = {
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "ramp_up_limit", False, expected_ramp_up_limit_results)
+
+
+def test_add_constraints_adds_ramp_down_limit_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    # Recall that steam to elec converter ramp_limit = 0.5; max_capacity_profile = [1, 1, 1]
+    m.flow.set_values(
+        {
+            ("steam_to_elec_converter", "steam", 0): 1.0,  # first t -> constraint skipped
+            ("steam_to_elec_converter", "steam", 1): 0.6,  # == max allowed ramp -> constr satisfied
+            ("steam_to_elec_converter", "steam", 2): 0.0,  # > max allowed ramp -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_ramp_down_limit_results = {
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "ramp_down_limit", False, expected_ramp_down_limit_results)
+
+
+def test_add_constraints_adds_ramp_track_up_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    m.flow.set_values(
+        {
+            ("steam_to_elec_converter", "steam", 0): 0.0,
+            ("steam_to_elec_converter", "steam", 1): 0.4,
+            ("steam_to_elec_converter", "steam", 2): 0.8,
+        }
+    )
+
+    m.ramp_up.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0.0,  # first t -> constraint skipped
+            ("steam_to_elec_converter", 1): 0.4,  # == flow difference -> constr satisfied
+            ("steam_to_elec_converter", 2): 0.3,  # < flow difference -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_ramp_track_up_results = {
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "ramp_track_up", False, expected_ramp_track_up_results)
+
+
+def test_add_constraints_adds_ramp_track_down_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    m.flow.set_values(
+        {
+            ("steam_to_elec_converter", "steam", 0): 0.8,
+            ("steam_to_elec_converter", "steam", 1): 0.4,
+            ("steam_to_elec_converter", "steam", 2): 0.0,
+        }
+    )
+
+    m.ramp_down.set_values(
+        {
+            ("steam_to_elec_converter", 0): 1.0,  # first t -> constraint skipped
+            ("steam_to_elec_converter", 1): 0.4,  # ramp == flow difference -> constr satisfied
+            ("steam_to_elec_converter", 2): 0.3,  # ramp < flow difference -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_ramp_track_up_results = {
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "ramp_track_down", False, expected_ramp_track_up_results)
+
+
+def test_add_constraints_adds_ramp_bin_up_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    m.ramp_up.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0.2,
+            ("steam_to_elec_converter", 1): 0.2,
+            ("steam_to_elec_converter", 2): 0.2,
+        }
+    )
+
+    m.ramp_up_bin.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0,  # first t -> constraint skipped
+            ("steam_to_elec_converter", 1): 1,  # ramping and binary = 1 -> constr satisfied
+            ("steam_to_elec_converter", 2): 0,  # ramping and binary = 0 -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_ramp_up_bin_results = {
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "ramp_bin_up", False, expected_ramp_up_bin_results)
+
+
+def test_add_constraints_adds_ramp_bin_down_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    m.ramp_down.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0.2,
+            ("steam_to_elec_converter", 1): 0.2,
+            ("steam_to_elec_converter", 2): 0.2,
+        }
+    )
+
+    m.ramp_down_bin.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0,  # first t -> constraint skipped
+            ("steam_to_elec_converter", 1): 1,  # ramping and binary = 1 -> constr satisfied
+            ("steam_to_elec_converter", 2): 0,  # ramping and binary = 0 -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_ramp_down_bin_results = {
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "ramp_bin_down", False, expected_ramp_down_bin_results)
+
+
+def test_add_constraints_adds_state_selection_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    m.ramp_up_bin.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0,
+            ("steam_to_elec_converter", 1): 1,
+            ("steam_to_elec_converter", 2): 0,
+        }
+    )
+    m.ramp_down_bin.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0,
+            ("steam_to_elec_converter", 1): 0,
+            ("steam_to_elec_converter", 2): 1,
+        }
+    )
+    m.steady_bin.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0,
+            ("steam_to_elec_converter", 1): 0,
+            ("steam_to_elec_converter", 2): 1,
+        }
+    )
+
+    # Expected results
+    expected_state_selection_results = {
+        ("steam_to_elec_converter", 0): False,  # zero of the bins are true -> constr fails
+        ("steam_to_elec_converter", 1): True,  # one of the bins is true -> constr succeeds
+        ("steam_to_elec_converter", 2): False,  # two of the bins are true -> constr fails
+    }
+
+    # Verify constraint
+    check_constraint(m, "state_selection", True, expected_state_selection_results)
+
+
+def test_add_constraints_adds_steady_state_upper_constraint(
+    add_constraints_setup, check_constraint
+):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    m.steady_bin.set_values(
+        {
+            ("steam_to_elec_converter", 0): 1,
+            ("steam_to_elec_converter", 1): 1,
+            ("steam_to_elec_converter", 2): 1,
+        }
+    )
+
+    m.ramp_up.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0.0,  # first t -> constraint skipped
+            ("steam_to_elec_converter", 1): 0.0,  # not ramping up; steady bin = 1 -> satisfied
+            ("steam_to_elec_converter", 2): 0.2,  # ramping up; steady bin = 1 -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_steady_state_upper_results = {
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "steady_state_upper", False, expected_steady_state_upper_results)
+
+
+def test_add_constraints_adds_steady_state_lower_constraint(
+    add_constraints_setup, check_constraint
+):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    m.steady_bin.set_values(
+        {
+            ("steam_to_elec_converter", 0): 1,
+            ("steam_to_elec_converter", 1): 1,
+            ("steam_to_elec_converter", 2): 1,
+        }
+    )
+
+    m.ramp_down.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0.0,  # first t -> constraint skipped
+            ("steam_to_elec_converter", 1): 0.0,  # not ramping down; steady bin = 1 -> satisfied
+            ("steam_to_elec_converter", 2): 0.2,  # ramping down; steady bin = 1 -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_steady_state_lower_results = {
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "steady_state_lower", False, expected_steady_state_lower_results)
+
+
+def test_add_constraints_adds_ramp_freq_window_constraint(add_constraints_setup, check_constraint):
+    m = add_constraints_setup.model
+
+    # Set up required vars for input
+    m.ramp_up_bin.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0,
+            ("steam_to_elec_converter", 1): 1,  # first ramp event in window -> cosntr satisfied
+            ("steam_to_elec_converter", 2): 0,
+        }
+    )
+
+    m.ramp_down_bin.set_values(
+        {
+            ("steam_to_elec_converter", 0): 0,
+            ("steam_to_elec_converter", 1): 0,
+            ("steam_to_elec_converter", 2): 1,  # second ramp event in window -> constr fails
+        }
+    )
+
+    # Expected results
+    expected_ramp_freq_window_results = {
+        ("steam_to_elec_converter", 1): True,
+        ("steam_to_elec_converter", 2): False,
+    }
+
+    # Verify constraint
+    check_constraint(m, "ramp_freq_window", False, expected_ramp_freq_window_results)
 
 
 def test_add_objective(add_constraints_setup):

--- a/tests/unit/test_components.py
+++ b/tests/unit/test_components.py
@@ -131,6 +131,29 @@ def test_sink_with_explicit_capacity_resource():
     assert sink.capacity_resource is r
 
 
+@pytest.mark.parametrize(
+    "bad_kwargs, msg_substr",
+    [
+        ({"ramp_limit": 1.1}, "ramp_limit"),
+        ({"ramp_freq": -1}, "ramp_freq"),
+    ],
+)
+def test_converter_bad_ramp_values_raise(bad_kwargs, msg_substr):
+    r1 = Resource(name="r1")
+    r2 = Resource(name="r2")
+    init_kwargs = {
+        "name": "conv",
+        "max_capacity_profile": [1.0],
+        "consumes": [r1],
+        "produces": [r2],
+        "transfer_fn": RatioTransfer(input_res=r1, output_res=r2),
+    }
+    init_kwargs.update(bad_kwargs)
+    with pytest.raises(ValueError) as exc:
+        Converter(**init_kwargs)
+    assert msg_substr in str(exc.value)
+
+
 def test_converter_same_resource_sets_capacity_and_warns():
     r = Resource(name="electricity")
     with pytest.warns(UserWarning):


### PR DESCRIPTION
This adds unit tests for the `ramp_limit` and `ramp_freq` attributes of converters that were added in #17.

In addition, the `steady_state_lower_rule` has been modified. This constraint previously forced `ramp_down` to be greater than or equal to zero when the converter is in steady state; however, `ramp_down` is defined such that it is always greater than zero when the converter is ramping down (see `ramp_track_down_rule` and `ramp_bin_down_rule`). Thus forcing `ramp_down` to be less than or equal to zero should acheive the desired functionality.

Finally, this change adds a check to ensure that `ramp_freq` is non-negative when a converter is created.