### PR TITLE
Update testing infrastructure

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,6 +23,29 @@ jobs:
       #     # Run Ruff for linting
       #     uvx ruff check .
 
-      - name: Run tests
-        # For example, using `pytest`
-        run: uv run pytest --cov --cov-branch
+      - name: Run unit tests
+        # Check branch coverage of the src/dove dir and automatically print coverage results
+        run: uv run pytest -m unit --cov=src/dove --cov-branch
+
+      - name: Run integration tests
+        # Append branch coverage of the src/dove dir and save results in html format
+        run: uv run pytest -m integration --cov=src/dove --cov-branch --cov-append --cov-report=html
+
+      - name: Print summary coverage results
+        run: echo "Total coverage from all tests:"
+        run: uv run coverage report
+        run: echo "For detailed coverage results, download 'coverage_results' artifact, unzip, and open 'index.html'."
+
+      - name: Archive detailed coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage_results
+          path: htmlcov
+
+      - name: Run examples
+        # This is to ensure that the examples run as expected, not to improve testing or coverage
+        # If any examples fail to run, this workflow will fail
+        run: uv run python examples/capacity_factor_example.py
+        run: uv run python examples/ramping_test.py
+        run: uv run python examples/storage_test.py
+        run: uv run python examples/transfer_example.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,15 @@ max-complexity = 12
 
 [tool.pytest.ini_options]
 minversion = "8.3.5"
-testpaths = ["tests"]
+testpaths = ["tests/unit", "tests/integration"]
 log_cli_level = "INFO"
 xfail_strict = true
 addopts = ["-ra", "--strict-config", "--strict-markers"]
 filterwarnings = ["error"]
+markers = [
+    "unit: Marks tests as unit tests, to be run before integration tests",
+    "integration: Marks tests as integration tests, to be run after unit tests"
+]
 
 [tool.mypy]
 exclude = [

--- a/tests/integration/test_basic_economics.py
+++ b/tests/integration/test_basic_economics.py
@@ -1,0 +1,213 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import dove.core as dc
+
+
+@pytest.fixture()
+def generic_system_setup():
+    def _generic_system_setup(
+        source_cfs=None, converter_cfs=None, storage_cfs=None, sink_cfs=None, times=1
+    ):
+        # Creates a generic system that can be used for simple tests on economics edge cases
+
+        # Resources
+        steam = dc.Resource(name="steam")
+        electricity = dc.Resource(name="electricity")
+
+        # Components
+        src_init_kwargs = {
+            "name": "steam_source",
+            "produces": steam,
+            "max_capacity_profile": np.full(times, 100),
+            "min_capacity_profile": np.full(times, 50),  # Force the system to do something at least
+        }
+        if source_cfs:
+            src_init_kwargs.update({"cashflows": source_cfs})
+        source = dc.Source(**src_init_kwargs)
+
+        conv_init_kwargs = {
+            "name": "steam_to_elec_converter",
+            "consumes": [steam],
+            "produces": [electricity],
+            "max_capacity_profile": np.full(times, 100),
+            "capacity_resource": steam,
+            "transfer_fn": dc.RatioTransfer(input_res=steam, output_res=electricity, ratio=0.5),
+        }
+        if converter_cfs:
+            conv_init_kwargs.update({"cashflows": converter_cfs})
+        converter = dc.Converter(**conv_init_kwargs)
+
+        stor_init_kwargs = {
+            "name": "elec_storage",
+            "resource": electricity,
+            "max_capacity_profile": np.full(times, 40),
+            "rte": 0.9,
+            "max_charge_rate": 0.5,
+            "max_discharge_rate": 0.5,
+        }
+        if storage_cfs:
+            stor_init_kwargs.update({"cashflows": storage_cfs})
+        storage = dc.Storage(**stor_init_kwargs)
+
+        sink_init_kwargs = {
+            "name": "elec_sink",
+            "consumes": electricity,
+            "max_capacity_profile": np.full(times, 100),
+        }
+        if sink_cfs:
+            sink_init_kwargs.update({"cashflows": sink_cfs})
+        sink = dc.Sink(**sink_init_kwargs)
+
+        # Times
+        time_index = np.arange(0, times)
+
+        # System
+        sys = dc.System(
+            components=[source, converter, storage, sink],
+            resources=[steam, electricity],
+            time_index=time_index,
+        )
+
+        return sys
+
+    return _generic_system_setup
+
+
+@pytest.mark.integration()
+def test_with_no_cfs(generic_system_setup):
+    # Create and solve system
+    sys = generic_system_setup(source_cfs=[], sink_cfs=[])
+    results = sys.solve("price_taker")
+    print(results)
+
+    # Check results
+    expected = pd.DataFrame(
+        {
+            "steam_source_steam_produces": [50.0],
+            "steam_to_elec_converter_electricity_produces": [25.0],
+            "steam_to_elec_converter_steam_consumes": [-50.0],
+            "elec_storage_SOC": [0.0],
+            "elec_storage_charge": [0.0],
+            "elec_storage_discharge": [0.0],
+            "elec_sink_electricity_consumes": [-25.0],
+            "objective": [0],
+        }
+    )
+
+    pd.testing.assert_frame_equal(results, expected, check_like=True, atol=1e-8)
+
+
+@pytest.mark.integration()
+def test_with_costs_only(generic_system_setup):
+    times = 4
+
+    # Set up cashflows
+    source_cost = dc.Cost(name="steam_source_fuel_cost", price_profile=np.arange(1 + times, 1))
+    sink_cost = dc.Cost(name="export_cost", alpha=1)
+
+    # Create and solve system
+    sys = generic_system_setup(source_cfs=[source_cost], sink_cfs=[sink_cost], times=times)
+    results = sys.solve("price_taker")
+    print(results)
+
+    # Check results
+    expected = pd.DataFrame(
+        {
+            "steam_source_steam_produces": [50.0, 50.0, 50.0, 50.0],
+            "steam_to_elec_converter_electricity_produces": [25.0, 25.0, 25.0, 25.0],
+            "steam_to_elec_converter_steam_consumes": [-50.0, -50.0, -50.0, -50.0],
+            "elec_storage_SOC": [0.0, 0.0, 2.108185, 0.0],
+            "elec_storage_charge": [20.0, 20.0, 20.0, 20.0],
+            "elec_storage_discharge": [18.0, 18, 16.0, 20.0],
+            "elec_sink_electricity_consumes": [-23.0, -23.0, -21.0, -25.0],
+            "objective": [-292.0, -292.0, -292.0, -292.0],
+        }
+    )
+
+    pd.testing.assert_frame_equal(results, expected, check_like=True, atol=1e-8)
+
+
+@pytest.mark.integration()
+def test_with_revenues_only(generic_system_setup):
+    times = 4
+
+    # Set up cashflow
+    elec_sales = dc.Revenue(name="elec_sales", price_profile=np.array([1, 1, 3, 1]))
+
+    # Create and solve system
+    sys = generic_system_setup(sink_cfs=[elec_sales], times=times)
+    results = sys.solve("price_taker")
+    print(results)
+
+    # Check results
+    expected = pd.DataFrame(
+        {
+            "steam_source_steam_produces": [100.0, 100.0, 100.0, 100.0],
+            "steam_to_elec_converter_electricity_produces": [50.0, 50.0, 50.0, 50.0],
+            "steam_to_elec_converter_steam_consumes": [-100.0, -100.0, -100.0, -100.0],
+            "elec_storage_SOC": [2.108185, 21.081851, 0.0, 0.0],
+            "elec_storage_charge": [2.222222, 20.0, 0.0, 0.0],
+            "elec_storage_discharge": [0.0, 0.0, 20.0, 0.0],
+            "elec_sink_electricity_consumes": [-47.777778, -30.0, -70.0, -50.0],
+            "objective": [337.777778, 337.777778, 337.777778, 337.777778],
+        }
+    )
+
+    pd.testing.assert_frame_equal(results, expected, check_like=True, atol=1e-8)
+
+
+@pytest.mark.integration()
+def test_cashflow_combos(generic_system_setup):
+    times = 4
+
+    # Set up cashflows
+    source1_fuel_cost = dc.Cost(name="source1_fuel_cost", price_profile=[1, 3, 2, 1])
+    source1_input_elec_cost = dc.Cost(name="source1_input_elec_cost", alpha=2)
+
+    source2_fuel_cost = dc.Cost(name="source2_fuel_cost", price_profile=[3, 4, 3, 5])
+    source2_revenue = dc.Revenue(
+        name="source2_revenue", alpha=1
+    )  # Not sure what practical scenario this would refer to
+
+    sink_elec_sales_regular = dc.Revenue(
+        name="sink1_elec_sales_regular", price_profile=[10, 10.5, 11, 11.5]
+    )
+    sink_elec_sales_spike = dc.Revenue(name="sink1_elec_sales_spike", price_profile=[0, 10, 0, 0])
+
+    # Create system, add extra component, and solve
+    sys = generic_system_setup(
+        source_cfs=[source1_fuel_cost, source1_input_elec_cost],
+        sink_cfs=[sink_elec_sales_regular, sink_elec_sales_spike],
+        times=times,
+    )
+
+    sys.add_component(
+        dc.Source(
+            name="elec_source",
+            produces=sys.res_map["electricity"],
+            max_capacity_profile=np.full(times, 20),
+            min_capacity_profile=np.full(times, 10),
+            cashflows=[source2_fuel_cost, source2_revenue],
+        )
+    )
+    results = sys.solve()
+    print(results)
+
+    # Check results
+    expected = pd.DataFrame(
+        {
+            "steam_source_steam_produces": [100.0, 100.0, 100.0, 100.0],
+            "elec_source_electricity_produces": [20.0, 20.0, 20.0, 20.0],
+            "steam_to_elec_converter_electricity_produces": [50.0, 50.0, 50.0, 50.0],
+            "steam_to_elec_converter_steam_consumes": [-100.0, -100.0, -100.0, -100.0],
+            "elec_storage_SOC": [18.973666, 0.0, 0.0, 0.0],
+            "elec_storage_charge": [20.0, 0.0, 0.0, 0.0],
+            "elec_storage_discharge": [0.0, 18.0, 0.0, 0.0],
+            "elec_sink_electricity_consumes": [-50.0, -88.0, -70.0, -70.0],
+            "objective": [2159.0, 2159.0, 2159.0, 2159.0],
+        }
+    )
+
+    pd.testing.assert_frame_equal(results, expected, check_like=True, atol=1e-8)

--- a/tests/unit/models/price_taker/test_builder.py
+++ b/tests/unit/models/price_taker/test_builder.py
@@ -84,6 +84,7 @@ def builder_setup(create_example_system):
     return price_taker_builder
 
 
+@pytest.mark.unit()
 def test_add_sets(builder_setup):
     # Call method under test
     builder_setup._add_sets()
@@ -114,6 +115,7 @@ def test_add_sets(builder_setup):
     assert list(actual_t) == expected_t  # We do care about the order for this one
 
 
+@pytest.mark.unit()
 def test_add_variables(builder_setup):
     # Add sets to builder so the variables can use them
     builder_setup._add_sets()
@@ -203,6 +205,7 @@ def check_constraint():
     return _check_constraint
 
 
+@pytest.mark.unit()
 def test_add_constraints_adds_transfer_constraint(add_constraints_setup, check_constraint):
     m = add_constraints_setup.model
     ### Transfer constraint
@@ -233,6 +236,7 @@ def test_add_constraints_adds_transfer_constraint(add_constraints_setup, check_c
     check_constraint(m, "transfer", True, expected_transfer_result)
 
 
+@pytest.mark.unit()
 def test_add_constraints_adds_max_capacity_constraint(add_constraints_setup, check_constraint):
     m = add_constraints_setup.model
 
@@ -272,6 +276,7 @@ def test_add_constraints_adds_max_capacity_constraint(add_constraints_setup, che
     check_constraint(m, "max_capacity", False, expected_cap_result)
 
 
+@pytest.mark.unit()
 def test_add_constraints_adds_min_capacity_constraint(add_constraints_setup, check_constraint):
     m = add_constraints_setup.model
 
@@ -308,6 +313,7 @@ def test_add_constraints_adds_min_capacity_constraint(add_constraints_setup, che
     check_constraint(m, "min_capacity", False, expected_min_cap_result)
 
 
+@pytest.mark.unit()
 def test_add_constraints_adds_resource_balance_constraint(add_constraints_setup, check_constraint):
     m = add_constraints_setup.model
 
@@ -365,6 +371,7 @@ def test_add_constraints_adds_resource_balance_constraint(add_constraints_setup,
     check_constraint(m, "resource_balance", True, expected_res_balance_result)
 
 
+@pytest.mark.unit()
 def test_add_constraints_adds_storage_balance_constraint(add_constraints_setup, check_constraint):
     m = add_constraints_setup.model
 
@@ -417,6 +424,7 @@ def test_add_constraints_adds_storage_balance_constraint(add_constraints_setup, 
     check_constraint(m, "storage_balance", True, expected_storage_balance_result)
 
 
+@pytest.mark.unit()
 def test_add_constraints_adds_charge_limit_constraint(add_constraints_setup, check_constraint):
     m = add_constraints_setup.model
 
@@ -448,6 +456,7 @@ def test_add_constraints_adds_charge_limit_constraint(add_constraints_setup, che
     check_constraint(m, "charge_limit", False, expected_charge_limit_result)
 
 
+@pytest.mark.unit()
 def test_add_constraints_adds_discharge_limit_constraint(add_constraints_setup, check_constraint):
     m = add_constraints_setup.model
 
@@ -479,6 +488,7 @@ def test_add_constraints_adds_discharge_limit_constraint(add_constraints_setup, 
     check_constraint(m, "discharge_limit", False, expected_discharge_limit_result)
 
 
+@pytest.mark.unit()
 def test_add_constraints_adds_soc_limit_constraint(add_constraints_setup, check_constraint):
     m = add_constraints_setup.model
 
@@ -509,6 +519,7 @@ def test_add_constraints_adds_soc_limit_constraint(add_constraints_setup, check_
     check_constraint(m, "soc_limit", False, expected_soc_limit_result)
 
 
+@pytest.mark.unit()
 def test_add_objective(add_constraints_setup):
     # Call the method under test
     add_constraints_setup._add_objective()
@@ -521,6 +532,7 @@ def test_add_objective(add_constraints_setup):
     assert not obj.is_minimizing()
 
 
+@pytest.mark.unit()
 def test_build(create_example_system):
     # Set up the builder
     builder_cls = BUILDER_REGISTRY["price_taker"]
@@ -575,6 +587,7 @@ def test_build(create_example_system):
     assert returned is builder
 
 
+@pytest.mark.unit()
 def test_extract_results(create_example_system):
     # Finish setup of builder
     builder_cls = BUILDER_REGISTRY["price_taker"]

--- a/tests/unit/test_components.py
+++ b/tests/unit/test_components.py
@@ -17,6 +17,7 @@ from dove.core import (
 )
 
 
+@pytest.mark.unit()
 def test_component_basic_properties():
     comp = Component(
         name="comp", max_capacity_profile=[5.0, 4.0, 5.0], min_capacity_profile=[1.0, 1.0, 2.0]
@@ -31,6 +32,7 @@ def test_component_basic_properties():
     assert comp.produces_by_name == []
 
 
+@pytest.mark.unit()
 @pytest.mark.parametrize(
     "kwargs, exc_type, msg_substr",
     [
@@ -59,6 +61,7 @@ def test_component_invalid_initialization(kwargs, exc_type, msg_substr):
     assert msg_substr in str(exc.value)
 
 
+@pytest.mark.unit()
 def test_component_capacity_resource_not_in_consumes_or_produces():
     r = Resource(name="res")
     with pytest.raises(ValueError) as exc:
@@ -66,11 +69,13 @@ def test_component_capacity_resource_not_in_consumes_or_produces():
     assert "capacity_resource" in str(exc.value)
 
 
+@pytest.mark.unit()
 def test_min_capacity_profile_set_for_fixed_flexibility():
     c = Component(name="c", max_capacity_profile=[2.0, 3.0], flexibility="fixed")
     assert c.min_capacity_profile.tolist() == [2.0, 3.0]
 
 
+@pytest.mark.unit()
 def test_min_capacity_profile_and_fixed_flexibility_specified_warns():
     with pytest.warns(UserWarning):
         c = Component(
@@ -82,6 +87,7 @@ def test_min_capacity_profile_and_fixed_flexibility_specified_warns():
     assert c.min_capacity_profile.tolist() == [2.0, 3.0]
 
 
+@pytest.mark.unit()
 def test_cf_price_profile_length_does_not_match():
     with pytest.raises(ValueError) as exc:
         Component(
@@ -92,6 +98,7 @@ def test_cf_price_profile_length_does_not_match():
     assert "cashflow price_profile length does not match" in str(exc.value)
 
 
+@pytest.mark.unit()
 def test_cf_price_profile_expanded():
     c = Component(
         name="c", max_capacity_profile=[1.0, 2.0], cashflows=[CashFlow(name="cf", alpha=2.0)]
@@ -99,6 +106,7 @@ def test_cf_price_profile_expanded():
     assert c.cashflows[0].price_profile.tolist() == [2.0, 2.0]
 
 
+@pytest.mark.unit()
 def test_source_defaults_transfer_function():
     r = Resource(name="water")
     src = Source(name="src", max_capacity_profile=[10.0], produces=r)
@@ -110,6 +118,7 @@ def test_source_defaults_transfer_function():
     assert tf.input_res is r and tf.output_res is r and tf.ratio == 1.0
 
 
+@pytest.mark.unit()
 @pytest.mark.parametrize(
     "bad_kwargs, msg_substr",
     [
@@ -126,12 +135,14 @@ def test_source_invalid_parameters_raise(bad_kwargs, msg_substr):
     assert msg_substr in str(exc.value)
 
 
+@pytest.mark.unit()
 def test_source_with_explicit_capacity_resource():
     r = Resource(name="r")
     src = Source(name="src", produces=r, max_capacity_profile=[1.0], capacity_resource=r)
     assert src.capacity_resource is r
 
 
+@pytest.mark.unit()
 def test_sink_defaults_transfer_function():
     r = Resource(name="fuel")
     sink = Sink(name="sink", max_capacity_profile=[8.0], consumes=r)
@@ -143,6 +154,7 @@ def test_sink_defaults_transfer_function():
     assert tf.input_res is r and tf.output_res is r and tf.ratio == 1.0
 
 
+@pytest.mark.unit()
 @pytest.mark.parametrize(
     "bad_kwargs, msg_substr",
     [
@@ -159,12 +171,14 @@ def test_sink_invalid_parameters_raise(bad_kwargs, msg_substr):
     assert msg_substr in str(exc.value)
 
 
+@pytest.mark.unit()
 def test_sink_with_explicit_capacity_resource():
     r = Resource(name="r")
     sink = Sink(name="sink", consumes=r, max_capacity_profile=[1.0], capacity_resource=r)
     assert sink.capacity_resource is r
 
 
+@pytest.mark.unit()
 def test_converter_same_resource_sets_capacity_and_warns():
     r = Resource(name="electricity")
     with pytest.warns(UserWarning):
@@ -178,6 +192,7 @@ def test_converter_same_resource_sets_capacity_and_warns():
     assert conv.capacity_resource is r
 
 
+@pytest.mark.unit()
 @pytest.mark.parametrize("has_transfer_fn", [True, False])
 def test_converter_ambiguous_capacity_resource_requires_explicit(has_transfer_fn):
     r1 = Resource(name="in_res")
@@ -191,6 +206,7 @@ def test_converter_ambiguous_capacity_resource_requires_explicit(has_transfer_fn
     assert "ambiguous capacity_resource" in str(exc.value)
 
 
+@pytest.mark.unit()
 def test_storage_default_capacity_and_valid_ranges():
     r = Resource(name="stor_res")
     st = Storage(name="stor", max_capacity_profile=[20.0], resource=r)
@@ -202,6 +218,7 @@ def test_storage_default_capacity_and_valid_ranges():
         assert 0.0 <= val <= 1.0
 
 
+@pytest.mark.unit()
 @pytest.mark.parametrize(
     "bad_kwargs, msg_substr",
     [

--- a/tests/unit/test_system.py
+++ b/tests/unit/test_system.py
@@ -44,6 +44,7 @@ def initialize_and_populate_system(request):
 ### TEST DEFINITIONS
 
 
+@pytest.mark.unit()
 def test_system_initialization_empty():
     sys = dc.System()
     assert isinstance(sys.components, list)
@@ -52,6 +53,7 @@ def test_system_initialization_empty():
     assert sys.resources == []
 
 
+@pytest.mark.unit()
 def test_system_summary(capsys):
     r = dc.Resource(name="res")
     src = dc.Source(name="src", max_capacity_profile=[4.0], produces=r)
@@ -69,6 +71,7 @@ def test_system_summary(capsys):
     assert "storage" in captured.out
 
 
+@pytest.mark.unit()
 def test_system_setup(initialize_and_populate_system):
     """
     Tests __init__, add_component, add_resource, non_storage_comp_names, and storage_comp_names
@@ -144,6 +147,7 @@ def test_system_setup(initialize_and_populate_system):
     assert sys.time_index == [1, 2, 4]
 
 
+@pytest.mark.unit()
 def test_adding_non_resource_to_resources_raises_error(initialize_and_populate_system):
     r1 = dc.Resource(name="r1")
     c = dc.Source(name="c1", produces=r1, max_capacity_profile=[1.0])
@@ -154,6 +158,7 @@ def test_adding_non_resource_to_resources_raises_error(initialize_and_populate_s
         )
 
 
+@pytest.mark.unit()
 def test_adding_duplicate_component_name_raises_error(initialize_and_populate_system):
     r = dc.Resource(name="res")
     c1 = dc.Source(name="c", produces=r, max_capacity_profile=[1.0], min_capacity_profile=[0.0])
@@ -162,6 +167,7 @@ def test_adding_duplicate_component_name_raises_error(initialize_and_populate_sy
         initialize_and_populate_system(resources=[r], components=[c1, c2])
 
 
+@pytest.mark.unit()
 def test_adding_duplicate_resource_name_raises_error(initialize_and_populate_system):
     r1 = dc.Resource(name="res")
     r2 = dc.Resource(name="res")
@@ -171,6 +177,7 @@ def test_adding_duplicate_resource_name_raises_error(initialize_and_populate_sys
         initialize_and_populate_system(resources=[r1, r2], components=[c1, c2])
 
 
+@pytest.mark.unit()
 def test_inconsistent_comp_profile_length_raises_error(initialize_and_populate_system):
     r = dc.Resource(name="res")
     c = dc.Source(name="c", produces=r, max_capacity_profile=[1.0], min_capacity_profile=[0.0])
@@ -179,6 +186,7 @@ def test_inconsistent_comp_profile_length_raises_error(initialize_and_populate_s
     assert "capacity profile length that does not match" in str(exc.value)
 
 
+@pytest.mark.unit()
 def test_solve_with_unknown_model_type_raises_error():
     r = dc.Resource(name="res")
     src = dc.Source(name="src", produces=r, max_capacity_profile=[1.0])

--- a/tests/unit/test_transfers.py
+++ b/tests/unit/test_transfers.py
@@ -13,6 +13,7 @@ class DummyResource:
         self.name = name
 
 
+@pytest.mark.unit()
 def test_ratio_transfer_enforces_ratio_true():
     res_in = DummyResource("in_res")
     res_out = DummyResource("out_res")
@@ -23,6 +24,7 @@ def test_ratio_transfer_enforces_ratio_true():
     assert rt(inputs, outputs) is True
 
 
+@pytest.mark.unit()
 def test_ratio_transfer_enforces_ratio_false():
     res_in = DummyResource("in_res")
     res_out = DummyResource("out_res")
@@ -33,6 +35,7 @@ def test_ratio_transfer_enforces_ratio_false():
     assert rt(inputs, outputs) is False
 
 
+@pytest.mark.unit()
 def test_ratio_transfer_only_output_skips_constraint():
     res_in = DummyResource("in_res")
     res_out = DummyResource("out_res")
@@ -43,6 +46,7 @@ def test_ratio_transfer_only_output_skips_constraint():
     assert result is Constraint.Skip
 
 
+@pytest.mark.unit()
 def test_ratio_transfer_only_input_skips_constraint():
     res_in = DummyResource("in_res")
     res_out = DummyResource("out_res")
@@ -53,6 +57,7 @@ def test_ratio_transfer_only_input_skips_constraint():
     assert result is Constraint.Skip
 
 
+@pytest.mark.unit()
 def test_ratio_transfer_no_vars_raises_value_error():
     res_in = DummyResource("in_res")
     res_out = DummyResource("out_res")
@@ -61,6 +66,7 @@ def test_ratio_transfer_no_vars_raises_value_error():
         rt({}, {})
 
 
+@pytest.mark.unit()
 def test_polynomial_transfer_single_term():
     # f(x) = 2 * x^2
     x = DummyResource("x")
@@ -70,6 +76,7 @@ def test_polynomial_transfer_single_term():
     assert pt(inputs, outputs) is True
 
 
+@pytest.mark.unit()
 def test_polynomial_transfer_multiple_terms():
     # f(x, z) = 1* x^1 * z^1 + 3* x^2
     x = DummyResource("x")
@@ -85,6 +92,7 @@ def test_polynomial_transfer_multiple_terms():
     assert pt(inputs, outputs) is True
 
 
+@pytest.mark.unit()
 def test_polynomial_transfer_empty_terms_zero_output():
     # no terms => expr = 0 => total_output must be 0
     pt = PolynomialTransfer(terms=[])
@@ -93,6 +101,7 @@ def test_polynomial_transfer_empty_terms_zero_output():
     assert pt(inputs, outputs) is True
 
 
+@pytest.mark.unit()
 def test_polynomial_transfer_mismatch_raises_false():
     # single term but outputs sum doesn't match
     x = DummyResource("x")


### PR DESCRIPTION
This change sets up some infrastructure for testing in DOVE. This includes:
- Adding pytest markers for unit and integration tests. This allows unit and integration tests to be run independently using a command like `uv run pytest -m unit` or `uv run pytest -m integration`
- Adding an example of an integration test that uses:
     - A pytest fixture for system setup
     - `pandas.testing` for checking and diffing results DataFrames
     - The new `integration` pytest marker
- Updating the github action so that it:
    - Runs unit tests, then only runs integration tests if the unit tests succeed
    - Provides more detailed coverage results, including printing the coverage data after running unit tests and creating an html report with line-by-line coverage information after all tests finish running
    - Runs examples to ensure that they do not error out