### PR TITLE
Add restrictions to accepted input arguments for Storage

### DIFF
--- a/src/dove/core/components.py
+++ b/src/dove/core/components.py
@@ -451,15 +451,18 @@ class Storage(Component):
         Initialize the Storage component after instance creation.
 
         This method validates input parameters of the Storage component:
-        - Sets the capacity_resource to resource if not provided
+        - Checks that unaccepted attributes for Storage components have not been added
         - Checks if parameters (rte, max_charge_rate, max_discharge_rate, initial_stored) are within the range [0, 1]
         - Calls the parent class's post-initialization method for additional validation
+        - Sets the capacity_resource to resource
 
         Raises
         ------
         ValueError
             If 'produces', 'consumes', or 'capacity_resource' was added
+            If 'flexibility' was set to 'fixed'
             If any of the rate parameters are outside the range [0, 1]
+            If 'max_capacity_profile' is not constant
         """
         # Error if unaccepted attribute was added
         for bad_attr in ("produces", "consumes", "capacity_resource"):
@@ -469,9 +472,12 @@ class Storage(Component):
                     "Please remove keyword argument."
                 )
 
-        super().__post_init__()
-        if self.capacity_resource is None:
-            self.capacity_resource = self.resource
+        # Error if flexibility was set to fixed
+        if self.flexibility == "fixed":
+            raise ValueError(
+                f"Attribute 'flexibility' was set to 'fixed' on Storage {self.name}. "
+                "Storage components must be flexible."
+            )
 
         # Error if parameters are outside [0, 1]
         for attr in ("rte", "max_charge_rate", "max_discharge_rate", "initial_stored"):
@@ -480,3 +486,15 @@ class Storage(Component):
                 raise ValueError(
                     f"Storage {self.name}: '{attr}'={val} is outside the range [0, 1].",
                 )
+
+        super().__post_init__()
+
+        # Error if max_capacity_profile is not constant
+        if not np.all(self.max_capacity_profile == self.max_capacity_profile[0]):
+            raise ValueError(
+                f"Non-constant max_capacity_profile was added to storage {self.name}. "
+                "Storage components must have constant max_capacity_profile values."
+            )
+
+        # Set capacity_resource
+        self.capacity_resource = self.resource

--- a/tests/unit/test_components.py
+++ b/tests/unit/test_components.py
@@ -225,6 +225,8 @@ def test_storage_default_capacity_and_valid_ranges():
         ({"produces": Resource(name="res")}, "produces"),
         ({"consumes": Resource(name="res")}, "consumes"),
         ({"capacity_resource": Resource(name="res")}, "capacity_resource"),
+        ({"flexibility": "fixed"}, "flexibility"),
+        ({"max_capacity_profile": [4.0, 5.0]}, "max_capacity_profile"),
         ({"rte": 1.5}, "rte"),
         ({"max_charge_rate": -0.1}, "max_charge_rate"),
         ({"max_discharge_rate": 2.0}, "max_discharge_rate"),
@@ -233,7 +235,7 @@ def test_storage_default_capacity_and_valid_ranges():
 )
 def test_storage_invalid_parameters_raise(bad_kwargs, msg_substr):
     r = Resource(name="stor_bad")
-    init_kwargs = {"name": "stor_bad", "max_capacity_profile": [5.0], "resource": r}
+    init_kwargs = {"name": "stor_bad", "max_capacity_profile": [5.0, 5.0], "resource": r}
     init_kwargs.update(bad_kwargs)
     with pytest.raises(ValueError) as exc:
         Storage(**init_kwargs)


### PR DESCRIPTION
Addresses:
#19
#32

This change places new restrictions on what inputs are accepted for Storage components and adds tests for these changes.