### PR TITLE
Update docs workflow to deploy when tags are pushed

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,14 +36,14 @@ jobs:
 
       - name: setup pages
         uses: actions/configure-pages@v5
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.repository == 'idaholab/DOVE' && github.ref_type == 'tag' }}
 
       - name: upload artifact
         uses: actions/upload-pages-artifact@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.repository == 'idaholab/DOVE' && github.ref_type == 'tag' }}
         with:
           path: "/tmp/dovedocs"
 
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.repository == 'idaholab/DOVE' && github.ref_type == 'tag' }}


### PR DESCRIPTION
This change updates the `deploy-docs.yml` github actions workflow file such that updated documentation is now published when tags are pushed to the `idaholab/DOVE` repository.