### PR TITLE
Feature/update transfer funcs

### DIFF
--- a/examples/ramping_test.py
+++ b/examples/ramping_test.py
@@ -60,7 +60,9 @@ def create_test_system(with_ramping=True):
         produces=[electricity],
         max_capacity_profile=np.full(len(hours), BOP_CAPACITY),
         capacity_resource=electricity,
-        transfer_fn=RatioTransfer({steam: 1.0}, {electricity: 0.333}),
+        transfer_fn=RatioTransfer(
+            input_resources={steam: 1.0}, output_resources={electricity: 0.333}
+        ),
     )
 
     # Apply ramping constraints if requested

--- a/examples/ramping_test.py
+++ b/examples/ramping_test.py
@@ -60,7 +60,7 @@ def create_test_system(with_ramping=True):
         produces=[electricity],
         max_capacity_profile=np.full(len(hours), BOP_CAPACITY),
         capacity_resource=electricity,
-        transfer_fn=RatioTransfer(steam, electricity, 0.333),
+        transfer_fn=RatioTransfer({steam: 1.0}, {electricity: 0.333}),
     )
 
     # Apply ramping constraints if requested

--- a/examples/storage_test.py
+++ b/examples/storage_test.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
         produces=[elec],
         max_capacity_profile=np.full(len(linear_price), 90),
         capacity_resource=steam,
-        transfer_fn=dc.RatioTransfer(steam, elec, 0.5),
+        transfer_fn=dc.RatioTransfer({steam: 1.0}, {elec: 0.5}),
     )
 
     # A Sink can only consume one resource. These components typically represent

--- a/examples/storage_test.py
+++ b/examples/storage_test.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
         produces=[elec],
         max_capacity_profile=np.full(len(linear_price), 90),
         capacity_resource=steam,
-        transfer_fn=dc.RatioTransfer({steam: 1.0}, {elec: 0.5}),
+        transfer_fn=dc.RatioTransfer(input_resources={steam: 1.0}, output_resources={elec: 0.5}),
     )
 
     # A Sink can only consume one resource. These components typically represent

--- a/examples/transfer_example.py
+++ b/examples/transfer_example.py
@@ -7,6 +7,7 @@ import dove.core as dc
 if __name__ == "__main__":
     funding = dc.Resource("funding")
     labor = dc.Resource("labor")
+    collaboration = dc.Resource("collaboration")
     work = dc.Resource("work")
 
     funding_source = dc.Source(
@@ -23,13 +24,29 @@ if __name__ == "__main__":
         flexibility="fixed",
     )
 
-    balance_ratio = dc.Converter(
-        name="BalanceRatio",
+    collaboration_source = dc.Source(
+        name="CollaborationSource",
+        produces=collaboration,
+        max_capacity_profile=[100],
+        flexibility="fixed",
+    )
+
+    balance_ratio_1 = dc.Converter(
+        name="BalanceRatio1",
         consumes=[funding],
         produces=[work],
         capacity_resource=funding,
         max_capacity_profile=[100],
-        transfer_fn=dc.RatioTransfer(funding, work, 0.25),
+        transfer_fn=dc.RatioTransfer({funding: 1.0}, {work: 0.25}),
+    )
+
+    balance_ratio_2 = dc.Converter(
+        name="BalanceRatio2",
+        consumes=[collaboration],
+        produces=[funding, work],
+        max_capacity_profile=[100],
+        capacity_resource=collaboration,
+        transfer_fn=dc.RatioTransfer({collaboration: 1.0}, {funding: 0.2, work: 0.1}),
     )
 
     quadratic = dc.Converter(
@@ -72,13 +89,14 @@ if __name__ == "__main__":
         components=[
             funding_source,
             labor_source,
-            balance_ratio,
+            balance_ratio_1,
+            balance_ratio_2,
             quadratic,
             work_sink,
             funding_sink,
             labor_sink,
         ],
-        resources=[funding, labor, work],
+        resources=[funding, labor, collaboration, work],
     )
     results = sys.solve(solver="ipopt")
     print(results)

--- a/examples/transfer_example.py
+++ b/examples/transfer_example.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         produces=[work],
         capacity_resource=funding,
         max_capacity_profile=[100],
-        transfer_fn=dc.RatioTransfer({funding: 1.0}, {work: 0.25}),
+        transfer_fn=dc.RatioTransfer(input_resources={funding: 1.0}, output_resources={work: 0.25}),
     )
 
     balance_ratio_2 = dc.Converter(
@@ -46,7 +46,9 @@ if __name__ == "__main__":
         produces=[funding, work],
         max_capacity_profile=[100],
         capacity_resource=collaboration,
-        transfer_fn=dc.RatioTransfer({collaboration: 1.0}, {funding: 0.2, work: 0.1}),
+        transfer_fn=dc.RatioTransfer(
+            input_resources={collaboration: 1.0}, output_resources={funding: 0.2, work: 0.1}
+        ),
     )
 
     quadratic = dc.Converter(

--- a/src/dove/core/__init__.py
+++ b/src/dove/core/__init__.py
@@ -23,7 +23,7 @@ from .components import (
 )
 from .resource import Resource
 from .system import System
-from .transfers import PolynomialTransfer, RatioTransfer, TransferFunc
+from .transfers import MultiRatioTransfer, PolynomialTransfer, RatioTransfer, TransferFunc
 
 __all__ = [
     "System",
@@ -37,6 +37,7 @@ __all__ = [
     "Resource",
     "Revenue",
     "RatioTransfer",
+    "MultiRatioTransfer",
     "PolynomialTransfer",
     "TransferFunc",
 ]

--- a/src/dove/core/__init__.py
+++ b/src/dove/core/__init__.py
@@ -23,7 +23,7 @@ from .components import (
 )
 from .resource import Resource
 from .system import System
-from .transfers import MultiRatioTransfer, PolynomialTransfer, RatioTransfer, TransferFunc
+from .transfers import PolynomialTransfer, RatioTransfer, TransferFunc
 
 __all__ = [
     "System",
@@ -37,7 +37,6 @@ __all__ = [
     "Resource",
     "Revenue",
     "RatioTransfer",
-    "MultiRatioTransfer",
     "PolynomialTransfer",
     "TransferFunc",
 ]

--- a/src/dove/core/components.py
+++ b/src/dove/core/components.py
@@ -258,7 +258,7 @@ class Source(Component):
 
         if self.transfer_fn is None:
             res = produces
-            self.transfer_fn = RatioTransfer(input_res=res, output_res=res, ratio=1.0)
+            self.transfer_fn = RatioTransfer(input_resources={}, output_resources={res: 1.0})
 
 
 @dataclass
@@ -311,7 +311,7 @@ class Sink(Component):
 
         if self.transfer_fn is None:
             res = consumes
-            self.transfer_fn = RatioTransfer(input_res=res, output_res=res, ratio=1.0)
+            self.transfer_fn = RatioTransfer(input_resources={res: 1.0}, output_resources={})
 
 
 @dataclass

--- a/src/dove/core/components.py
+++ b/src/dove/core/components.py
@@ -470,7 +470,7 @@ class Storage(Component):
             If 'max_capacity_profile' is not constant
         """
         # Error if unaccepted attribute was added
-        for bad_attr in ("produces", "consumes", "capacity_resource"):
+        for bad_attr in ("produces", "consumes", "capacity_resource", "transfer_fn"):
             if getattr(self, bad_attr):
                 raise ValueError(
                     f"Unaccepted keyword argument '{bad_attr}' provided to Storage {self.name}. "

--- a/src/dove/core/transfers.py
+++ b/src/dove/core/transfers.py
@@ -12,7 +12,8 @@ or economic transformations such as energy conversion, efficiency losses, or
 material transformations.
 
 The module defines two main transfer function types:
-- RatioTransfer: Simple linear relationship between inputs and outputs (e.g., efficiency)
+- RatioTransfer: Simple linear relationship between one input and one output (e.g., efficiency)
+- MultiRatioTransfer: Linear relationship between multiple inputs and outputs
 - PolynomialTransfer: More complex non-linear relationship described by polynomial terms
 
 These transfer functions can be used to model various energy conversion processes
@@ -121,6 +122,7 @@ class RatioTransfer:
             )
 
 
+@dataclass()
 class MultiRatioTransfer:
     """
     A transfer class that enforces ratio relationships between multiple input and output resources.
@@ -188,16 +190,16 @@ class MultiRatioTransfer:
             If an input or output resource cannot be found in the dispatch variables
         """
         for input_res in self.input_resources:
-            if input_res not in inputs:
+            if input_res.name not in inputs:
                 raise ValueError(
-                    f"MultiRatioTransfer: Input resource {input_res.name} "
+                    f"MultiRatioTransfer: Input resource '{input_res.name}' "
                     "not found in the provided dispatch variable for inputs"
                 )
 
         for output_res in self.output_resources:
-            if output_res not in outputs:
+            if output_res.name not in outputs:
                 raise ValueError(
-                    f"MultiRatioTransfer: Output resource {output_res.name} "
+                    f"MultiRatioTransfer: Output resource '{output_res.name}' "
                     "not found in the provided dispatch variable for outputs"
                 )
 

--- a/src/dove/core/transfers.py
+++ b/src/dove/core/transfers.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 TransferFunc: TypeAlias = "RatioTransfer | PolynomialTransfer"
 
 
-@dataclass()
+@dataclass
 class RatioTransfer:
     """
     A transfer class that enforces ratio relationships between multiple input and output resources.

--- a/src/dove/models/price_taker/builder.py
+++ b/src/dove/models/price_taker/builder.py
@@ -201,8 +201,7 @@ class PriceTakerBuilder(BaseModelBuilder):
 
     def _add_transfer_block(self) -> None:
         """
-        Add a block to the optimization model to handle variables
-        and constraints related to resource transfer.
+        Add a block to the optimization model to handle constraints related to resource transfer.
         """
         m = self.model
         m.transfer = pyo.Block(m.NON_STORAGE, m.T, rule=prl.transfer_block_rule)

--- a/src/dove/models/price_taker/builder.py
+++ b/src/dove/models/price_taker/builder.py
@@ -84,6 +84,7 @@ class PriceTakerBuilder(BaseModelBuilder):
 
         self._add_sets()
         self._add_variables()
+        self._add_transfer_block()
         self._add_constraints()
         self._add_objective()
 
@@ -198,6 +199,14 @@ class PriceTakerBuilder(BaseModelBuilder):
             m.ramp_down_bin = pyo.Var(m.NON_STORAGE, m.T, within=pyo.Binary)
             m.steady_bin = pyo.Var(m.NON_STORAGE, m.T, within=pyo.Binary)
 
+    def _add_transfer_block(self) -> None:
+        """
+        Add a block to the optimization model to handle variables
+        and constraints related to resource transfer.
+        """
+        m = self.model
+        m.transfer = pyo.Block(m.NON_STORAGE, m.T, rule=prl.transfer_block_rule)
+
     def _add_constraints(self) -> None:
         """
         Add constraints to the optimization model.
@@ -215,7 +224,6 @@ class PriceTakerBuilder(BaseModelBuilder):
         """
         m = self.model
 
-        m.transfer = pyo.Constraint(m.NON_STORAGE, m.T, rule=prl.transfer_rule)
         m.max_capacity = pyo.Constraint(m.NON_STORAGE, m.T, rule=prl.max_capacity_rule)
         m.min_capacity = pyo.Constraint(m.NON_STORAGE, m.T, rule=prl.min_capacity_rule)
 

--- a/src/dove/models/price_taker/rulelib.py
+++ b/src/dove/models/price_taker/rulelib.py
@@ -70,8 +70,8 @@ def transfer_block_rule(b: pyo.Block, cname: str, t: int) -> None:
     # Get the model's current behavior (flows)
     m = b.model()
     comp = m.system.comp_map[cname]
-    input_res_quantities = {r.name: m.flow[cname, "consumes", r.name, t] for r in comp.consumes}
-    output_res_quantities = {r.name: m.flow[cname, "produces", r.name, t] for r in comp.produces}
+    input_res_quantities = {r.name: m.flow[cname, r.name, t] for r in comp.consumes}
+    output_res_quantities = {r.name: m.flow[cname, r.name, t] for r in comp.produces}
 
     # Apply transfer function to get list of values that should be equal
     tf_values = comp.transfer_fn(input_res_quantities, output_res_quantities)
@@ -82,10 +82,10 @@ def transfer_block_rule(b: pyo.Block, cname: str, t: int) -> None:
         b.transfer_size = pyo.Var(within=pyo.NonNegativeReals)
 
         # Create constraint to force equality of all returned values
-        def transfer_rule(b: pyo.Block, req_value: float) -> pyo.Expression:
-            return req_value == b.transfer_size
+        def transfer_rule(b: pyo.Block, i: int) -> pyo.Expression:
+            return tf_values[i] == b.transfer_size
 
-        b.transfer_constr = pyo.Constraint(tf_values, rule=transfer_rule)
+        b.transfer_constr = pyo.Constraint(range(len(tf_values)), rule=transfer_rule)
 
 
 def max_capacity_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:

--- a/tests/integration/test_basic_economics.py
+++ b/tests/integration/test_basic_economics.py
@@ -40,7 +40,9 @@ def generic_system_setup():
             "produces": [electricity],
             "max_capacity_profile": np.full(times, 100),
             "capacity_resource": steam,
-            "transfer_fn": dc.RatioTransfer(input_res=steam, output_res=electricity, ratio=0.5),
+            "transfer_fn": dc.RatioTransfer(
+                input_resources={steam: 1.0}, output_resources={electricity: 0.5}
+            ),
         }
         if converter_cfs:
             conv_init_kwargs.update({"cashflows": converter_cfs})

--- a/tests/unit/models/price_taker/test_builder.py
+++ b/tests/unit/models/price_taker/test_builder.py
@@ -43,7 +43,7 @@ def create_example_system():
         capacity_resource=steam,
         ramp_freq=2,
         ramp_limit=0.4,
-        transfer_fn=dc.RatioTransfer(input_res=steam, output_res=elec, ratio=0.5),
+        transfer_fn=dc.RatioTransfer(input_resources={steam: 1.0}, output_resources={elec: 0.5}),
     )
 
     elec_sink = dc.Sink(
@@ -171,6 +171,45 @@ def test_add_variables(builder_setup):
     assert actual_steady_bin_keys == expected_ramp_keys
 
 
+@pytest.mark.unit()
+def test_add_transfer_block(builder_setup):
+    builder_setup._add_sets()
+    builder_setup._add_variables()
+    builder_setup._add_transfer_block()  # Method under test
+
+    m = builder_setup.model
+    b = getattr(m, "transfer", None)
+    assert b is not None
+
+    # Check that the keys are correct
+    expected_keys = [
+        ("steam_source", 0),
+        ("steam_source", 1),
+        ("steam_source", 2),
+        ("steam_to_elec_converter", 0),
+        ("steam_to_elec_converter", 1),
+        ("steam_to_elec_converter", 2),
+        ("elec_sink", 0),
+        ("elec_sink", 1),
+        ("elec_sink", 2),
+    ]
+
+    assert set(b.keys()) == set(expected_keys)
+
+    # Check that the correct variable and constraint have been added to the block
+    # It's hard to test more than this without solving the model
+    for cname, time in expected_keys:
+        transfer_size = getattr(b[cname, time], "transfer_size", None)
+        transfer_constr = getattr(b[cname, time], "transfer_constr", None)
+        if cname == "steam_to_elec_converter":
+            # Var and Constraint should only be created if the transfer function has >=2 terms
+            assert isinstance(transfer_size, pyo.Var)
+            assert isinstance(transfer_constr, pyo.Constraint)
+        else:
+            assert transfer_size is None
+            assert transfer_constr is None
+
+
 @pytest.fixture()
 def add_constraints_setup(builder_setup):
     # Add sets and variables to builder so the constraints can use them
@@ -185,11 +224,14 @@ def add_constraints_setup(builder_setup):
 @pytest.fixture()
 def check_constraint():
     def _check_constraint(
-        model: pyo.ConcreteModel, constr_name: str, is_equality_constr: bool, expected_result: dict
+        parent: pyo.ConcreteModel | pyo.Block,
+        constr_name: str,
+        is_equality_constr: bool,
+        expected_result: dict,
     ) -> None:
         """
         Ensure constraint is correct by checking that it exists, that the keys are correct,
-        that it is is of the type (equality/inequality) expected, and that it is satisfied when expected.
+        that it is of the type (equality/inequality) expected, and that it is satisfied when expected.
 
         Parameters
         ----------
@@ -203,7 +245,7 @@ def check_constraint():
             A dict with keys that are tuples that mirror the expected keys of the constraint (or bins for the
             constraint to populate) and values that are bools with the expected feasibility of the constraint.
         """
-        actual_constr = getattr(model, constr_name, None)
+        actual_constr = getattr(parent, constr_name, None)
 
         assert actual_constr is not None
         assert set(actual_constr.keys()) == set(expected_result.keys())
@@ -226,37 +268,6 @@ def check_constraint():
             assert (satisfies_lb and satisfies_ub) == value
 
     return _check_constraint
-
-
-@pytest.mark.unit()
-def test_add_constraints_adds_transfer_constraint(add_constraints_setup, check_constraint):
-    m = add_constraints_setup.model
-    ### Transfer constraint
-
-    # Set up required vars for input
-    # Recall that for the converter, ratio_transfer ratio == 0.5
-    m.flow.set_values(
-        {
-            ("steam_to_elec_converter", "steam",       0): 0.0,
-            ("steam_to_elec_converter", "electricity", 0): 1.0,  # Out > 0.5 * In -> constr fails
-
-            ("steam_to_elec_converter", "steam",       1): 2.0,
-            ("steam_to_elec_converter", "electricity", 1): 1.0,  # Out == 0.5 * In -> constr satisfied
-
-            ("steam_to_elec_converter", "steam",       2): 1.0,
-            ("steam_to_elec_converter", "electricity", 2): 0.0,  # Out < 0.5 * In -> constr fails
-        }
-    )  # fmt: skip
-
-    # Expected results
-    expected_transfer_result = {
-        ("steam_to_elec_converter", 0): False,
-        ("steam_to_elec_converter", 1): True,
-        ("steam_to_elec_converter", 2): False,
-    }
-
-    # Verify constraint
-    check_constraint(m, "transfer", True, expected_transfer_result)
 
 
 @pytest.mark.unit()
@@ -917,7 +928,6 @@ def test_build(create_example_system):
 
     # Check that constraints were added
     expected_constr_names = [
-        "transfer",
         "max_capacity",
         "min_capacity",
         "resource_balance",

--- a/tests/unit/test_components.py
+++ b/tests/unit/test_components.py
@@ -203,33 +203,43 @@ def test_converter_bad_ramp_values_raise(bad_kwargs, msg_substr):
 
 
 @pytest.mark.unit()
-def test_converter_same_resource_sets_capacity_and_warns():
+@pytest.mark.parametrize(
+    "required_kwarg, msg_substr",
+    [
+        ("capacity_resource", "'capacity_resource' was not provided"),
+        ("transfer_fn", "'transfer_fn' was not provided"),
+    ],
+)
+def test_converter_missing_required_kwarg_raises(required_kwarg, msg_substr):
+    r1 = Resource(name="r1")
+    r2 = Resource(name="r2")
+    init_kwargs = {
+        "name": "conv",
+        "max_capacity_profile": [1.0],
+        "consumes": [r1],
+        "produces": [r2],
+        "capacity_resource": r1,
+        "transfer_fn": RatioTransfer(input_resources={r1: 1.0}, output_resources={r2: 1.0}),
+    }
+    del init_kwargs[required_kwarg]
+    with pytest.raises(ValueError) as exc:
+        Converter(**init_kwargs)
+    assert msg_substr in str(exc.value)
+
+
+@pytest.mark.unit()
+def test_converter_same_resource_raises():
     r = Resource(name="electricity")
-    with pytest.warns(UserWarning):
-        conv = Converter(
+    with pytest.raises(ValueError) as exc:
+        Converter(
             name="conv",
             max_capacity_profile=[15.0],
             consumes=[r],
             produces=[r],
+            capacity_resource=r,
             transfer_fn=RatioTransfer(input_resources={r: 1.0}, output_resources={r: 1.0}),
         )
-    assert conv.capacity_resource is r
-
-
-@pytest.mark.unit()
-@pytest.mark.parametrize("has_transfer_fn", [True, False])
-def test_converter_ambiguous_capacity_resource_requires_explicit(has_transfer_fn):
-    r1 = Resource(name="in_res")
-    r2 = Resource(name="out_res")
-    init_kwargs = {"name": "amb", "max_capacity_profile": [5.0], "consumes": [r1], "produces": [r2]}
-    if has_transfer_fn:
-        init_kwargs.update(
-            {"transfer_fn": RatioTransfer(input_resources={r1: 1.0}, output_resources={r2: 1.0})}
-        )
-    # missing transfer_fn and ambiguous resources
-    with pytest.raises(ValueError) as exc:
-        Converter(**init_kwargs)
-    assert "ambiguous capacity_resource" in str(exc.value)
+    assert "Resource 'electricity' found in both" in str(exc.value)
 
 
 @pytest.mark.unit()

--- a/tests/unit/test_components.py
+++ b/tests/unit/test_components.py
@@ -115,7 +115,7 @@ def test_source_defaults_transfer_function():
     assert src.capacity_resource is r
     tf = src.transfer_fn
     assert isinstance(tf, RatioTransfer)
-    assert tf.input_res is r and tf.output_res is r and tf.ratio == 1.0
+    assert tf.input_resources == {} and tf.output_resources == {r: 1.0}
 
 
 @pytest.mark.unit()
@@ -151,7 +151,7 @@ def test_sink_defaults_transfer_function():
     assert sink.capacity_resource is r
     tf = sink.transfer_fn
     assert isinstance(tf, RatioTransfer)
-    assert tf.input_res is r and tf.output_res is r and tf.ratio == 1.0
+    assert tf.input_resources == {r: 1.0} and tf.output_resources == {}
 
 
 @pytest.mark.unit()
@@ -211,7 +211,7 @@ def test_converter_same_resource_sets_capacity_and_warns():
             max_capacity_profile=[15.0],
             consumes=[r],
             produces=[r],
-            transfer_fn=RatioTransfer(input_res=r, output_res=r),
+            transfer_fn=RatioTransfer(input_resources={r: 1.0}, output_resources={r: 1.0}),
         )
     assert conv.capacity_resource is r
 
@@ -223,7 +223,9 @@ def test_converter_ambiguous_capacity_resource_requires_explicit(has_transfer_fn
     r2 = Resource(name="out_res")
     init_kwargs = {"name": "amb", "max_capacity_profile": [5.0], "consumes": [r1], "produces": [r2]}
     if has_transfer_fn:
-        init_kwargs.update({"transfer_fn": RatioTransfer(input_res=r1, output_res=r2)})
+        init_kwargs.update(
+            {"transfer_fn": RatioTransfer(input_resources={r1: 1.0}, output_resources={r2: 1.0})}
+        )
     # missing transfer_fn and ambiguous resources
     with pytest.raises(ValueError) as exc:
         Converter(**init_kwargs)

--- a/tests/unit/test_components.py
+++ b/tests/unit/test_components.py
@@ -194,7 +194,7 @@ def test_converter_bad_ramp_values_raise(bad_kwargs, msg_substr):
         "max_capacity_profile": [1.0],
         "consumes": [r1],
         "produces": [r2],
-        "transfer_fn": RatioTransfer(input_res=r1, output_res=r2),
+        "transfer_fn": RatioTransfer(input_resources={r1: 1.0}, output_resources={r2: 1.0}),
     }
     init_kwargs.update(bad_kwargs)
     with pytest.raises(ValueError) as exc:

--- a/tests/unit/test_system.py
+++ b/tests/unit/test_system.py
@@ -97,7 +97,7 @@ def test_system_setup(initialize_and_populate_system):
         consumes=[r_w],
         produces=[r_e],
         capacity_resource=r_w,
-        transfer_fn=dc.RatioTransfer(input_res=r_w, output_res=r_e, ratio=1.0),
+        transfer_fn=dc.RatioTransfer(input_resources={r_w: 1.0}, output_resources={r_e: 1.0}),
         cashflows=[dc.Cost(name="conv_cf", alpha=2)],
     )
     storage = dc.Storage(

--- a/tests/unit/test_transfers.py
+++ b/tests/unit/test_transfers.py
@@ -9,7 +9,7 @@ from dove.core.transfers import PolynomialTransfer, RatioTransfer
 
 
 @pytest.mark.unit()
-def test_ratio_transfer_enforces_ratio_true():
+def test_siso_ratio_transfer_enforces_ratio_true():
     res_in = Resource("in_res")
     res_out = Resource("out_res")
     rt = RatioTransfer(input_resources={res_in: 1.0}, output_resources={res_out: 2.5})
@@ -22,7 +22,7 @@ def test_ratio_transfer_enforces_ratio_true():
 
 
 @pytest.mark.unit()
-def test_ratio_transfer_enforces_ratio_false():
+def test_siso_ratio_transfer_enforces_ratio_false():
     res_in = Resource("in_res")
     res_out = Resource("out_res")
     rt = RatioTransfer(input_resources={res_in: 1.0}, output_resources={res_out: 3.0})
@@ -32,6 +32,60 @@ def test_ratio_transfer_enforces_ratio_false():
     result_reqs = rt(inputs, outputs)
     assert len(result_reqs) == 1
     assert result_reqs[0] is False
+
+
+@pytest.mark.unit()
+def test_mimo_ratio_transfer_enforces_ratio_true():
+    res_in_1 = Resource("in_res_1")
+    res_in_2 = Resource("in_res_2")
+    res_out_1 = Resource("out_res_1")
+    res_out_2 = Resource("out_res_2")
+    rt = RatioTransfer(
+        input_resources={res_in_1: 1.0, res_in_2: 2.0},
+        output_resources={res_out_1: 1.5, res_out_2: 2.5},
+    )
+    inputs = {"in_res_1": 3.0, "in_res_2": 6.0}
+    outputs = {"out_res_1": 4.5, "out_res_2": 7.5}
+    # 3.0/1.0 == 6.0/2.0 == 4.5/1.5 == 7.5/2.5
+    result_reqs = rt(inputs, outputs)
+    assert len(result_reqs) == 3
+    assert all(req is True for req in result_reqs)
+
+
+@pytest.mark.unit()
+def test_mimo_ratio_transfer_enforces_ratio_wrong_input():
+    res_in_1 = Resource("in_res_1")
+    res_in_2 = Resource("in_res_2")
+    res_out_1 = Resource("out_res_1")
+    res_out_2 = Resource("out_res_2")
+    rt = RatioTransfer(
+        input_resources={res_in_1: 1.0, res_in_2: 2.0},
+        output_resources={res_out_1: 1.5, res_out_2: 2.5},
+    )
+    inputs = {"in_res_1": 6.0, "in_res_2": 6.0}  # in_res_1 should be 3, not 6
+    outputs = {"out_res_1": 4.5, "out_res_2": 7.5}
+    # 6.0/1.0 != 6.0/2.0 == 4.5/1.5 == 7.5/2.5
+    result_reqs = rt(inputs, outputs)
+    assert len(result_reqs) == 3
+    assert not all(req is True for req in result_reqs)
+
+
+@pytest.mark.unit()
+def test_mimo_ratio_transfer_enforces_ratio_wrong_output():
+    res_in_1 = Resource("in_res_1")
+    res_in_2 = Resource("in_res_2")
+    res_out_1 = Resource("out_res_1")
+    res_out_2 = Resource("out_res_2")
+    rt = RatioTransfer(
+        input_resources={res_in_1: 1.0, res_in_2: 2.0},
+        output_resources={res_out_1: 1.5, res_out_2: 2.5},
+    )
+    inputs = {"in_res_1": 3.0, "in_res_2": 6.0}
+    outputs = {"out_res_1": 4.5, "out_res_2": 6.0}  # out_res_2 should be 7.5, not 6
+    # 3.0/1.0 == 6.0/2.0 == 4.5/1.5 != 6.0/2.5
+    result_reqs = rt(inputs, outputs)
+    assert len(result_reqs) == 3
+    assert not all(req is True for req in result_reqs)
 
 
 @pytest.mark.unit()

--- a/tests/unit/test_transfers.py
+++ b/tests/unit/test_transfers.py
@@ -16,8 +16,9 @@ def test_ratio_transfer_enforces_ratio_true():
     inputs = {"in_res": 4.0}
     outputs = {"out_res": 10.0}
     # 10.0 == 2.5 * 4.0
-    result_vals = rt(inputs, outputs)
-    assert all(val == result_vals[0] for val in result_vals[1:])
+    result_reqs = rt(inputs, outputs)
+    assert len(result_reqs) == 1
+    assert result_reqs[0] is True
 
 
 @pytest.mark.unit()
@@ -28,8 +29,9 @@ def test_ratio_transfer_enforces_ratio_false():
     inputs = {"in_res": 2.0}
     outputs = {"out_res": 5.9}
     # 5.9 != 3.0 * 2.0
-    result_vals = rt(inputs, outputs)
-    assert not all(val == result_vals[0] for val in result_vals[1:])
+    result_reqs = rt(inputs, outputs)
+    assert len(result_reqs) == 1
+    assert result_reqs[0] is False
 
 
 @pytest.mark.unit()
@@ -70,8 +72,9 @@ def test_polynomial_transfer_single_term():
     pt = PolynomialTransfer(terms=[(2.0, {x: 2})])
     inputs = {"x": 3.0}
     outputs = {"y": 18.0}  # total_output = 18.0
-    result_vals = pt(inputs, outputs)
-    assert all(val == result_vals[0] for val in result_vals[1:])
+    result_reqs = pt(inputs, outputs)
+    assert len(result_reqs) == 1
+    assert result_reqs[0] is True
 
 
 @pytest.mark.unit()
@@ -87,8 +90,9 @@ def test_polynomial_transfer_multiple_terms():
     inputs = {"x": 2.0, "z": 5.0}
     # expected = 1*(2*5) + 3*(2**2) = 10 + 12 = 22
     outputs = {"out1": 10.0, "out2": 12.0}
-    result_vals = pt(inputs, outputs)
-    assert all(val == result_vals[0] for val in result_vals[1:])
+    result_reqs = pt(inputs, outputs)
+    assert len(result_reqs) == 1
+    assert result_reqs[0] is True
 
 
 @pytest.mark.unit()
@@ -97,8 +101,9 @@ def test_polynomial_transfer_empty_terms_zero_output():
     pt = PolynomialTransfer(terms=[])
     inputs = {"a": 100.0}
     outputs = {"o1": 0.0, "o2": 0.0}
-    result_vals = pt(inputs, outputs)
-    assert all(val == result_vals[0] for val in result_vals[1:])
+    result_reqs = pt(inputs, outputs)
+    assert len(result_reqs) == 1
+    assert result_reqs[0] is True
 
 
 @pytest.mark.unit()
@@ -108,5 +113,6 @@ def test_polynomial_transfer_mismatch_raises_false():
     pt = PolynomialTransfer(terms=[(5.0, {x: 1})])
     inputs = {"x": 2.0}
     outputs = {"y": 8.0}  # expected 5*2 = 10
-    result_vals = pt(inputs, outputs)
-    assert not all(val == result_vals[0] for val in result_vals[1:])
+    result_reqs = pt(inputs, outputs)
+    assert len(result_reqs) == 1
+    assert result_reqs[0] is False

--- a/tests/unit/test_transfers.py
+++ b/tests/unit/test_transfers.py
@@ -3,65 +3,62 @@
 """ """
 
 import pytest
-from pyomo.environ import Constraint
 
+from dove.core import Resource
 from dove.core.transfers import PolynomialTransfer, RatioTransfer
-
-
-class DummyResource:
-    def __init__(self, name):
-        self.name = name
 
 
 @pytest.mark.unit()
 def test_ratio_transfer_enforces_ratio_true():
-    res_in = DummyResource("in_res")
-    res_out = DummyResource("out_res")
-    rt = RatioTransfer(input_res=res_in, output_res=res_out, ratio=2.5)
+    res_in = Resource("in_res")
+    res_out = Resource("out_res")
+    rt = RatioTransfer(input_resources={res_in: 1.0}, output_resources={res_out: 2.5})
     inputs = {"in_res": 4.0}
     outputs = {"out_res": 10.0}
     # 10.0 == 2.5 * 4.0
-    assert rt(inputs, outputs) is True
+    result_vals = rt(inputs, outputs)
+    assert all(val == result_vals[0] for val in result_vals[1:])
 
 
 @pytest.mark.unit()
 def test_ratio_transfer_enforces_ratio_false():
-    res_in = DummyResource("in_res")
-    res_out = DummyResource("out_res")
-    rt = RatioTransfer(input_res=res_in, output_res=res_out, ratio=3.0)
+    res_in = Resource("in_res")
+    res_out = Resource("out_res")
+    rt = RatioTransfer(input_resources={res_in: 1.0}, output_resources={res_out: 3.0})
     inputs = {"in_res": 2.0}
     outputs = {"out_res": 5.9}
     # 5.9 != 3.0 * 2.0
-    assert rt(inputs, outputs) is False
+    result_vals = rt(inputs, outputs)
+    assert not all(val == result_vals[0] for val in result_vals[1:])
 
 
 @pytest.mark.unit()
-def test_ratio_transfer_only_output_skips_constraint():
-    res_in = DummyResource("in_res")
-    res_out = DummyResource("out_res")
-    rt = RatioTransfer(input_res=res_in, output_res=res_out, ratio=1.0)
+def test_ratio_transfer_only_output_raises_value_error():
+    res_in = Resource("in_res")
+    res_out = Resource("out_res")
+    rt = RatioTransfer(input_resources={res_in: 1.0}, output_resources={res_out: 1.0})
     inputs = {}
     outputs = {"out_res": 7.0}
-    result = rt(inputs, outputs)
-    assert result is Constraint.Skip
+    with pytest.raises(ValueError):
+        rt(inputs, outputs)
 
 
 @pytest.mark.unit()
-def test_ratio_transfer_only_input_skips_constraint():
-    res_in = DummyResource("in_res")
-    res_out = DummyResource("out_res")
-    rt = RatioTransfer(input_res=res_in, output_res=res_out, ratio=1.0)
+def test_ratio_transfer_only_input_raises_value_error():
+    res_in = Resource("in_res")
+    res_out = Resource("out_res")
+    rt = RatioTransfer(input_resources={res_in: 1.0}, output_resources={res_out: 1.0})
     inputs = {"in_res": 7.0}
     outputs = {}
-    result = rt(inputs, outputs)
-    assert result is Constraint.Skip
+    with pytest.raises(ValueError):
+        rt(inputs, outputs)
 
 
 @pytest.mark.unit()
 def test_ratio_transfer_no_vars_raises_value_error():
-    res_in = DummyResource("in_res")
-    res_out = DummyResource("out_res")
-    rt = RatioTransfer(input_res=res_in, output_res=res_out, ratio=1.0)
+    res_in = Resource("in_res")
+    res_out = Resource("out_res")
+    rt = RatioTransfer(input_resources={res_in: 1.0}, output_resources={res_out: 1.0})
     with pytest.raises(ValueError):
         rt({}, {})
 
@@ -69,18 +66,19 @@ def test_ratio_transfer_no_vars_raises_value_error():
 @pytest.mark.unit()
 def test_polynomial_transfer_single_term():
     # f(x) = 2 * x^2
-    x = DummyResource("x")
+    x = Resource("x")
     pt = PolynomialTransfer(terms=[(2.0, {x: 2})])
     inputs = {"x": 3.0}
     outputs = {"y": 18.0}  # total_output = 18.0
-    assert pt(inputs, outputs) is True
+    result_vals = pt(inputs, outputs)
+    assert all(val == result_vals[0] for val in result_vals[1:])
 
 
 @pytest.mark.unit()
 def test_polynomial_transfer_multiple_terms():
     # f(x, z) = 1* x^1 * z^1 + 3* x^2
-    x = DummyResource("x")
-    z = DummyResource("z")
+    x = Resource("x")
+    z = Resource("z")
     terms = [
         (1.0, {x: 1, z: 1}),  # x*z
         (3.0, {x: 2}),  # 3*x^2
@@ -89,7 +87,8 @@ def test_polynomial_transfer_multiple_terms():
     inputs = {"x": 2.0, "z": 5.0}
     # expected = 1*(2*5) + 3*(2**2) = 10 + 12 = 22
     outputs = {"out1": 10.0, "out2": 12.0}
-    assert pt(inputs, outputs) is True
+    result_vals = pt(inputs, outputs)
+    assert all(val == result_vals[0] for val in result_vals[1:])
 
 
 @pytest.mark.unit()
@@ -98,14 +97,16 @@ def test_polynomial_transfer_empty_terms_zero_output():
     pt = PolynomialTransfer(terms=[])
     inputs = {"a": 100.0}
     outputs = {"o1": 0.0, "o2": 0.0}
-    assert pt(inputs, outputs) is True
+    result_vals = pt(inputs, outputs)
+    assert all(val == result_vals[0] for val in result_vals[1:])
 
 
 @pytest.mark.unit()
 def test_polynomial_transfer_mismatch_raises_false():
     # single term but outputs sum doesn't match
-    x = DummyResource("x")
+    x = Resource("x")
     pt = PolynomialTransfer(terms=[(5.0, {x: 1})])
     inputs = {"x": 2.0}
     outputs = {"y": 8.0}  # expected 5*2 = 10
-    assert pt(inputs, outputs) is False
+    result_vals = pt(inputs, outputs)
+    assert not all(val == result_vals[0] for val in result_vals[1:])


### PR DESCRIPTION
This pull request updates the handling of transfer functions such that the RatioTransfer now accepts multiple inputs and multiple outputs. Note that DOVE does not yet accept transfer functions that have the same resource as an input and an output.

Transfer functions have also been updated such that they now return a list of pyomo Expressions (an Expression is similar to a boolean constructed with `==`, `<=`, or `>=`) instead of a single pyomo expression. The pyomo model construction enforces all of these expressions in an indexed constraint. This allows for more flexible transfer functions since they handle the creation of pyomo expressions themselves and can specify as many requirements as are necessary.

Tests have been added and updated for these changes.

Update: changes to Converter in commit [29f6199](https://github.com/idaholab/DOVE/pull/38/commits/29f6199f3761a7664fa003a4ca4e0397bea3df50) address #16.