### PR TITLE
fix: address mypy errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,10 @@ strict = true
 warn_unreachable = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 
+[[tool.mypy.overrides]]
+module = ["pyomo.*"]
+ignore_missing_imports = true
+
 [tool.codespell]
 skip = './docs/build,./tests/pyomo_tests'
 count = true

--- a/src/dove/core/cashflow.py
+++ b/src/dove/core/cashflow.py
@@ -77,7 +77,7 @@ class CashFlow(ABC):
         Returns the cashflow's dollar value at the given timestep t, provided a dispatch quantity.
         Recall that a positive value indicates a revenue and a negative value indicates a cost.
         """
-        value = self.sign * self.alpha * ((dispatch / self.dprime) ** self.scalex)
+        value: float = self.sign * self.alpha * ((dispatch / self.dprime) ** self.scalex)
         if len(self.price_profile) > 0:
             if t > len(self.price_profile) - 1:
                 available = (

--- a/src/dove/core/components.py
+++ b/src/dove/core/components.py
@@ -366,9 +366,9 @@ class Sink(Component):
         if self.demand_profile is not None:
             # installed_capacity should never be needed in the model if demand_profile is
             # provided, but it's still required by the Component, so we'll give it a value
-            comp_init_kwargs.update({"installed_capacity": np.max(demand_profile)})
+            comp_init_kwargs.update({"installed_capacity": np.max(demand_profile)})  # type: ignore[arg-type]
 
-        super().__init__(**comp_init_kwargs)
+        super().__init__(**comp_init_kwargs)  # type: ignore[arg-type]
 
         if self.transfer_fn is None:
             res = consumes

--- a/src/dove/core/system.py
+++ b/src/dove/core/system.py
@@ -18,11 +18,11 @@ Classes
 
 from __future__ import annotations
 
-from typing import Any, Self
+from typing import Any, Self, cast
 
 from dove.models import BUILDER_REGISTRY
 
-from . import Component, Resource, Storage
+from . import Component, Resource, Sink, Storage
 
 
 class System:
@@ -164,9 +164,11 @@ class System:
                 "min_capacity_factor": comp.min_capacity_factor,
             }
             if getattr(comp, "demand_profile", None) is not None:
-                time_series.update({"demand_profile": comp.demand_profile})
+                comp = cast("Sink", comp)  # Must be a Sink if it has demand_profile
+                time_series.update({"demand_profile": comp.demand_profile})  # type: ignore[dict-item]
             if getattr(comp, "min_demand_profile", None) is not None:
-                time_series.update({"min_demand_profile": comp.min_demand_profile})
+                comp = cast("Sink", comp)  # Must be a Sink if it has min_demand_profile
+                time_series.update({"min_demand_profile": comp.min_demand_profile})  # type: ignore[dict-item]
             time_series.update(
                 {f"{cf.name} price_profile": cf.price_profile for cf in comp.cashflows}
             )

--- a/src/dove/models/price_taker/builder.py
+++ b/src/dove/models/price_taker/builder.py
@@ -32,7 +32,7 @@ dove.models.base.BaseModelBuilder : Parent class providing the base builder inte
 from typing import Any, Self
 
 import pandas as pd
-import pyomo.environ as pyo  # type: ignore[import-untyped]
+import pyomo.environ as pyo
 
 from dove.models import register_builder
 from dove.models.base import BaseModelBuilder
@@ -79,7 +79,7 @@ class PriceTakerBuilder(BaseModelBuilder):
         Self
             The builder instance, allowing for method chaining.
         """
-        self.model = pyo.ConcreteModel()
+        self.model: pyo.ConcreteModel = pyo.ConcreteModel()
         self.model.system = self.system
 
         self._add_sets()
@@ -144,7 +144,8 @@ class PriceTakerBuilder(BaseModelBuilder):
             for cf in comp.cashflows:
                 for t in T:
                     net_cashflow[t] += cf.evaluate(
-                        t, pyo.value(m.flow[comp.name, comp.capacity_resource.name, t])
+                        t,
+                        pyo.value(m.flow[comp.name, comp.capacity_resource.name, t]),  # type: ignore[union-attr]
                     )
 
         data["net_cashflow"] = net_cashflow

--- a/src/dove/models/price_taker/rulelib.py
+++ b/src/dove/models/price_taker/rulelib.py
@@ -29,7 +29,7 @@ a 'system' attribute containing component and resource information.
 
 from typing import TYPE_CHECKING
 
-import pyomo.environ as pyo  # type: ignore[import-untyped]
+import pyomo.environ as pyo
 
 if TYPE_CHECKING:
     from dove.core import Storage
@@ -144,7 +144,7 @@ def minimum_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:
     return m.flow[cname, comp.capacity_resource.name, t] >= comp.minimum_at_timestep(t)
 
 
-def ramp_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
+def ramp_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:
     """
     Limit rate of increase in component output between time periods.
 
@@ -159,7 +159,7 @@ def ramp_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
 
     Returns
     -------
-    pyo.Constraint
+    pyo.Expression
         Constraint limiting upward ramping or Constraint.Skip
     """
     system = m.system
@@ -171,7 +171,7 @@ def ramp_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
     return m.flow[cname, res, t] - m.flow[cname, res, m.T.prev(t)] <= max_allowed_ramp
 
 
-def ramp_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
+def ramp_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:
     """
     Limit rate of decrease in component output between time periods.
 
@@ -186,7 +186,7 @@ def ramp_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
 
     Returns
     -------
-    pyo.Constraint
+    pyo.Expression
         Constraint limiting downward ramping or Constraint.Skip
     """
     system = m.system
@@ -198,7 +198,7 @@ def ramp_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
     return m.flow[cname, res, m.T.prev(t)] - m.flow[cname, res, t] <= max_allowed_ramp
 
 
-def ramp_track_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
+def ramp_track_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:
     """
     Track upward ramps for a component.
 
@@ -213,7 +213,7 @@ def ramp_track_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constrai
 
     Returns
     -------
-    pyo.Constraint
+    pyo.Expression
         Constraint tracking upward ramps or Constraint.Skip
     """
     system = m.system
@@ -224,7 +224,7 @@ def ramp_track_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constrai
     return m.ramp_up[cname, t] >= m.flow[cname, res, t] - m.flow[cname, res, m.T.prev(t)]
 
 
-def ramp_track_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
+def ramp_track_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:
     """
     Track downward ramps for a component.
 
@@ -239,7 +239,7 @@ def ramp_track_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constr
 
     Returns
     -------
-    pyo.Constraint
+    pyo.Expression
         Constraint tracking downward ramps or Constraint.Skip
     """
     system = m.system
@@ -250,7 +250,7 @@ def ramp_track_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constr
     return m.ramp_down[cname, t] >= m.flow[cname, res, m.T.prev(t)] - m.flow[cname, res, t]
 
 
-def ramp_bin_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
+def ramp_bin_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:
     """
     Limit upward ramp size based on binary variable.
 
@@ -265,7 +265,7 @@ def ramp_bin_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint
 
     Returns
     -------
-    pyo.Constraint
+    pyo.Expression
         Constraint limiting ramp size or Constraint.Skip
     """
     system = m.system
@@ -275,7 +275,7 @@ def ramp_bin_up_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint
     return m.ramp_up[cname, t] <= comp.installed_capacity * m.ramp_up_bin[cname, t]
 
 
-def ramp_bin_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
+def ramp_bin_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:
     """
     Limit downward ramp size based on binary variable.
 
@@ -290,7 +290,7 @@ def ramp_bin_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constrai
 
     Returns
     -------
-    pyo.Constraint
+    pyo.Expression
         Constraint limiting ramp size or Constraint.Skip
     """
     system = m.system
@@ -300,7 +300,7 @@ def ramp_bin_down_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constrai
     return m.ramp_down[cname, t] <= comp.installed_capacity * m.ramp_down_bin[cname, t]
 
 
-def ramp_freq_window_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
+def ramp_freq_window_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:
     """
     Limit frequency of ramping events within a time window.
 
@@ -315,7 +315,7 @@ def ramp_freq_window_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Const
 
     Returns
     -------
-    pyo.Constraint
+    pyo.Expression
         Constraint limiting ramp frequency or Constraint.Skip
     """
     system = m.system
@@ -331,7 +331,7 @@ def ramp_freq_window_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Const
     return sum(m.ramp_up_bin[cname, tw] + m.ramp_down_bin[cname, tw] for tw in freq_window) <= 1
 
 
-def steady_state_upper_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
+def steady_state_upper_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:
     """
     Define upper bound for steady state operation (no flow increase if in steady state).
 
@@ -346,7 +346,7 @@ def steady_state_upper_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Con
 
     Returns
     -------
-    pyo.Constraint
+    pyo.Expression
         Upper bound constraint for steady state or Constraint.Skip
     """
     system = m.system
@@ -359,7 +359,7 @@ def steady_state_upper_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Con
     return m.ramp_up[cname, t] <= M * (1 - m.steady_bin[cname, t])
 
 
-def steady_state_lower_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
+def steady_state_lower_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:
     """
     Define lower bound for steady state operation (no flow decrease if in steady state).
 
@@ -374,7 +374,7 @@ def steady_state_lower_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Con
 
     Returns
     -------
-    pyo.Constraint
+    pyo.Expression
         Lower bound constraint for steady state or Constraint.Skip
     """
     system = m.system
@@ -387,7 +387,7 @@ def steady_state_lower_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Con
     return m.ramp_down[cname, t] >= -M * (1 - m.steady_bin[cname, t])
 
 
-def state_selection_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constraint:
+def state_selection_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Expression:
     """
     Ensure exactly one operational state is active at each time step.
 
@@ -402,7 +402,7 @@ def state_selection_rule(m: pyo.ConcreteModel, cname: str, t: int) -> pyo.Constr
 
     Returns
     -------
-    pyo.Constraint
+    pyo.Expression
         Component must be in exactly one state (up, down, or steady)
     """
     # If no components spcecify a non-default ramp_freq, then skip
@@ -567,7 +567,7 @@ def soc_limit_rule(m: pyo.ConcreteModel, sname: str, t: int) -> pyo.Expression:
     return m.soc[sname, t] <= comp.capacity_at_timestep(t)
 
 
-def periodic_storage_rule(m: pyo.ConcreteModel, sname: str) -> pyo.Constraint:
+def periodic_storage_rule(m: pyo.ConcreteModel, sname: str) -> pyo.Expression:
     """
     Enforce periodic storage level for a storage component.
 
@@ -583,7 +583,7 @@ def periodic_storage_rule(m: pyo.ConcreteModel, sname: str) -> pyo.Constraint:
 
     Returns
     -------
-    pyo.Constraint
+    pyo.Expression
         A Pyomo constraint enforcing periodic storage level.
     """
     comp = m.system.comp_map[sname]


### PR DESCRIPTION
This addresses the errors found by mypy when running `mypy --strict src/dove`. Most of these errors are from typing complexities that mypy fails to interpret correctly, so the solution is to add a `# type: ignore[<error>]` comment or adding extra annotations.